### PR TITLE
feat(api): add interested and want-to-try reactions to nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ bun.lock
 # JWT decode utility (temporary files)
 decode-jwt.js
 query.sql
+
+# MCP
+.serena

--- a/apps/api/migrations/20260205154510_add_reactions.sql
+++ b/apps/api/migrations/20260205154510_add_reactions.sql
@@ -1,0 +1,30 @@
+-- Create "interested" table
+CREATE TABLE `interested` (
+  `node_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `created_at` text NOT NULL,
+  PRIMARY KEY (`node_id`, `user_id`),
+  CONSTRAINT `0` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT `1` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "idx_interested_node_id" to table: "interested"
+CREATE INDEX `idx_interested_node_id` ON `interested` (`node_id`);
+-- Create index "idx_interested_user_id" to table: "interested"
+CREATE INDEX `idx_interested_user_id` ON `interested` (`user_id`);
+-- Create index "idx_interested_created_at" to table: "interested"
+CREATE INDEX `idx_interested_created_at` ON `interested` (`created_at`);
+-- Create "want_to_try" table
+CREATE TABLE `want_to_try` (
+  `node_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `created_at` text NOT NULL,
+  PRIMARY KEY (`node_id`, `user_id`),
+  CONSTRAINT `0` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT `1` FOREIGN KEY (`node_id`) REFERENCES `nodes` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "idx_want_to_try_node_id" to table: "want_to_try"
+CREATE INDEX `idx_want_to_try_node_id` ON `want_to_try` (`node_id`);
+-- Create index "idx_want_to_try_user_id" to table: "want_to_try"
+CREATE INDEX `idx_want_to_try_user_id` ON `want_to_try` (`user_id`);
+-- Create index "idx_want_to_try_created_at" to table: "want_to_try"
+CREATE INDEX `idx_want_to_try_created_at` ON `want_to_try` (`created_at`);

--- a/apps/api/migrations/atlas.sum
+++ b/apps/api/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:mUFHO8ilDTL4Mdrv5B9ddfssJyPxyXMK/92RmaGBxnc=
+h1:kK26r9QYjR5xu5mjJ9MNhZdFW/bx1qfZ6XlRGi+m+iA=
 20260119143327_initial.sql h1:zGKI5feJYYrSbgg9In6j5dhKhMiOMX+CCqu6g/+PYqw=
 20260129121007_add_nodes_and_social_features.sql h1:Egmj9Sg+aAYa1tOF4SNGOQdfJxMz9xvvDYeGAA/dGBU=
+20260205154510_add_reactions.sql h1:vWAPjRI3l0XvKcoYK6uUu33qTagtIdZM9xD7fT2kgB0=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "api",
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev src/index.tsx --local --port 8787 --persist-to=./.wrangler/state",
+    "dev": "wrangler dev --local --port 8787 --persist-to=./.wrangler/state",
     "build": "vite build",
     "preview": "$npm_execpath run build && vite preview",
     "deploy": "$npm_execpath run build && wrangler deploy",
@@ -14,7 +14,9 @@
     "format:check": "oxfmt src/",
     "test": "bun test",
     "test:watch": "bun test --watch",
-    "test:coverage": "bun test --coverage"
+    "test:coverage": "bun test --coverage",
+    "db:diff": "atlas migrate diff --env local",
+    "db:apply": "wrangler d1 migrations apply DB --local"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20260118.0",

--- a/apps/api/schema.sql
+++ b/apps/api/schema.sql
@@ -116,3 +116,31 @@ CREATE TABLE likes (
 CREATE INDEX idx_likes_node_id ON likes(node_id);
 CREATE INDEX idx_likes_user_id ON likes(user_id);
 CREATE INDEX idx_likes_created_at ON likes(created_at);
+
+-- Interested table (気になる機能)
+CREATE TABLE interested (
+  node_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (node_id, user_id),
+  FOREIGN KEY (node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_interested_node_id ON interested(node_id);
+CREATE INDEX idx_interested_user_id ON interested(user_id);
+CREATE INDEX idx_interested_created_at ON interested(created_at);
+
+-- Want to try table (やってみたい機能)
+CREATE TABLE want_to_try (
+  node_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (node_id, user_id),
+  FOREIGN KEY (node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_want_to_try_node_id ON want_to_try(node_id);
+CREATE INDEX idx_want_to_try_user_id ON want_to_try(user_id);
+CREATE INDEX idx_want_to_try_created_at ON want_to_try(created_at);

--- a/apps/api/src/lib/db.ts
+++ b/apps/api/src/lib/db.ts
@@ -11,6 +11,8 @@ export interface Database {
   comments: CommentsTable;
   comment_mentions: CommentMentionsTable;
   likes: LikesTable;
+  interested: InterestedTable;
+  want_to_try: WantToTryTable;
 }
 
 export interface UsersTable {
@@ -71,6 +73,18 @@ export interface CommentMentionsTable {
 }
 
 export interface LikesTable {
+  node_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+export interface InterestedTable {
+  node_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+export interface WantToTryTable {
   node_id: string;
   user_id: string;
   created_at: string;

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -25,6 +25,17 @@ import { ErrorResponseSchema } from "../schemas/auth";
 import { type } from "arktype";
 
 // Response schemas
+const ReactionStatusSchema = type({
+  count: "number",
+  "is_reacted?": "boolean",
+});
+
+const ReactionsSchema = type({
+  like: ReactionStatusSchema,
+  interested: ReactionStatusSchema,
+  want_to_try: ReactionStatusSchema,
+});
+
 const NodeResponseSchema = type({
   id: "string",
   type: "'issue' | 'idea' | 'project'",
@@ -41,9 +52,8 @@ const NodeResponseSchema = type({
       name: "string",
     },
   ]),
-  like_count: "number",
+  reactions: ReactionsSchema,
   comment_count: "number",
-  "is_liked?": "boolean",
 });
 
 const CreateNodeResponseSchema = type({
@@ -56,10 +66,10 @@ const ListNodesResponseSchema = type({
   total: "number",
 });
 
-const LikeResponseSchema = type({
-  liked: "boolean",
-  like_count: "number",
-});
+const ReactionToggleResponseSchema = type({
+  is_reacted: "boolean",
+  count: "number",
+});;
 
 const nodes = new Hono<HonoEnv>();
 
@@ -95,30 +105,49 @@ nodes.get(
       offset: query.offset || 0,
     });
 
-    // Get user's like status if authenticated
+    // Get user's reaction statuses if authenticated
     const authHeader = c.req.header("Authorization");
     let likeStatuses: Record<string, boolean> = {};
+    let interestedStatuses: Record<string, boolean> = {};
+    let wantToTryStatuses: Record<string, boolean> = {};
 
     if (authHeader) {
       try {
         const userId = c.get("userId");
         if (userId) {
           const nodeIds = nodesList.map((n) => n.id);
-          likeStatuses = await nodeService.getUserLikeStatus(nodeIds, userId);
+          [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
+            nodeService.getUserLikeStatus(nodeIds, userId),
+            nodeService.getUserInterestedStatus(nodeIds, userId),
+            nodeService.getUserWantToTryStatus(nodeIds, userId),
+          ]);
         }
       } catch {
         // Optional auth, ignore errors
       }
     }
 
-    const nodesWithLikeStatus = nodesList.map((node) => ({
+    const nodesWithReactionStatus = nodesList.map((node) => ({
       ...node,
-      is_liked: likeStatuses[node.id] || false,
+      reactions: {
+        like: {
+          count: node.reactions.like.count,
+          is_reacted: likeStatuses[node.id] || false,
+        },
+        interested: {
+          count: node.reactions.interested.count,
+          is_reacted: interestedStatuses[node.id] || false,
+        },
+        want_to_try: {
+          count: node.reactions.want_to_try.count,
+          is_reacted: wantToTryStatuses[node.id] || false,
+        },
+      },
     }));
 
     return c.json({
-      nodes: nodesWithLikeStatus,
-      total: nodesWithLikeStatus.length,
+      nodes: nodesWithReactionStatus,
+      total: nodesWithReactionStatus.length,
     });
   },
 );
@@ -166,15 +195,23 @@ nodes.get(
       );
     }
 
-    // Check if user has liked this node
-    let isLiked = false;
+    // Check user's reaction statuses
+    let likeStatus = false;
+    let interestedStatus = false;
+    let wantToTryStatus = false;
     const authHeader = c.req.header("Authorization");
     if (authHeader) {
       try {
         const userId = c.get("userId");
         if (userId) {
-          const likeStatuses = await nodeService.getUserLikeStatus([id], userId);
-          isLiked = likeStatuses[id] || false;
+          const [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
+            nodeService.getUserLikeStatus([id], userId),
+            nodeService.getUserInterestedStatus([id], userId),
+            nodeService.getUserWantToTryStatus([id], userId),
+          ]);
+          likeStatus = likeStatuses[id] || false;
+          interestedStatus = interestedStatuses[id] || false;
+          wantToTryStatus = wantToTryStatuses[id] || false;
         }
       } catch {
         // Optional auth, ignore errors
@@ -183,7 +220,20 @@ nodes.get(
 
     return c.json({
       ...node,
-      is_liked: isLiked,
+      reactions: {
+        like: {
+          count: node.reactions.like.count,
+          is_reacted: likeStatus,
+        },
+        interested: {
+          count: node.reactions.interested.count,
+          is_reacted: interestedStatus,
+        },
+        want_to_try: {
+          count: node.reactions.want_to_try.count,
+          is_reacted: wantToTryStatus,
+        },
+      },
     });
   },
 );
@@ -413,7 +463,7 @@ nodes.post(
         description: "いいね切り替え成功",
         content: {
           "application/json": {
-            schema: resolver(LikeResponseSchema),
+            schema: resolver(ReactionToggleResponseSchema),
           },
         },
       },
@@ -451,13 +501,131 @@ nodes.post(
     }
 
     const result = await nodeService.toggleLike(nodeId, userId);
-
-    // Get updated like count
-    const updatedNode = await nodeService.getById(nodeId);
+    const count = await nodeService.getReactionCount(nodeId, "like");
 
     return c.json({
-      liked: result.liked,
-      like_count: updatedNode?.like_count || 0,
+      is_reacted: result.liked,
+      count,
+    });
+  },
+);
+
+// POST /nodes/:id/interested - Toggle interested on a node
+nodes.post(
+  "/:id/interested",
+  describeRoute({
+    tags: ["Nodes"],
+    summary: "気になる切り替え",
+    description: "ノードの気になる状態を切り替え",
+    security: [{ Bearer: [] }],
+    responses: {
+      200: {
+        description: "気になる切り替え成功",
+        content: {
+          "application/json": {
+            schema: resolver(ReactionToggleResponseSchema),
+          },
+        },
+      },
+      404: {
+        description: "ノードが見つかりません",
+        content: {
+          "application/json": {
+            schema: resolver(ErrorResponseSchema),
+          },
+        },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const nodeId = c.req.param("id");
+    const userId = c.get("userId");
+    if (!userId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const db = createDb(c.env.DB);
+    const nodeService = new NodeService(db);
+
+    // Check if node exists
+    const node = await nodeService.getById(nodeId);
+    if (!node) {
+      return c.json(
+        {
+          success: false as const,
+          error: { code: "NOT_FOUND", message: "Node not found" },
+        },
+        404,
+      );
+    }
+
+    const result = await nodeService.toggleInterested(nodeId, userId);
+    const count = await nodeService.getReactionCount(nodeId, "interested");
+
+    return c.json({
+      is_reacted: result.is_reacted,
+      count,
+    });
+  },
+);
+
+// POST /nodes/:id/want-to-try - Toggle want-to-try on a node
+nodes.post(
+  "/:id/want-to-try",
+  describeRoute({
+    tags: ["Nodes"],
+    summary: "やってみたい切り替え",
+    description: "ノードのやってみたい状態を切り替え",
+    security: [{ Bearer: [] }],
+    responses: {
+      200: {
+        description: "やってみたい切り替え成功",
+        content: {
+          "application/json": {
+            schema: resolver(ReactionToggleResponseSchema),
+          },
+        },
+      },
+      404: {
+        description: "ノードが見つかりません",
+        content: {
+          "application/json": {
+            schema: resolver(ErrorResponseSchema),
+          },
+        },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const nodeId = c.req.param("id");
+    const userId = c.get("userId");
+    if (!userId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const db = createDb(c.env.DB);
+    const nodeService = new NodeService(db);
+
+    // Check if node exists
+    const node = await nodeService.getById(nodeId);
+    if (!node) {
+      return c.json(
+        {
+          success: false as const,
+          error: { code: "NOT_FOUND", message: "Node not found" },
+        },
+        404,
+      );
+    }
+
+    const result = await nodeService.toggleWantToTry(nodeId, userId);
+    const count = await nodeService.getReactionCount(nodeId, "want_to_try");
+
+    return c.json({
+      is_reacted: result.is_reacted,
+      count,
     });
   },
 );

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -97,24 +97,38 @@ export class NodeService {
       .where("node_tags.node_id", "=", id)
       .execute();
 
-    // Get like count
-    const likeCount = await this.db
-      .selectFrom("likes")
-      .select((eb) => eb.fn.countAll().as("count"))
-      .where("node_id", "=", id)
-      .executeTakeFirst();
-
-    // Get comment count
-    const commentCount = await this.db
-      .selectFrom("comments")
-      .select((eb) => eb.fn.countAll().as("count"))
-      .where("node_id", "=", id)
-      .executeTakeFirst();
+    // Get reaction counts
+    const [likeCount, interestedCount, wantToTryCount, commentCount] = await Promise.all([
+      this.db
+        .selectFrom("likes")
+        .select((eb) => eb.fn.countAll().as("count"))
+        .where("node_id", "=", id)
+        .executeTakeFirst(),
+      this.db
+        .selectFrom("interested")
+        .select((eb) => eb.fn.countAll().as("count"))
+        .where("node_id", "=", id)
+        .executeTakeFirst(),
+      this.db
+        .selectFrom("want_to_try")
+        .select((eb) => eb.fn.countAll().as("count"))
+        .where("node_id", "=", id)
+        .executeTakeFirst(),
+      this.db
+        .selectFrom("comments")
+        .select((eb) => eb.fn.countAll().as("count"))
+        .where("node_id", "=", id)
+        .executeTakeFirst(),
+    ]);
 
     return {
       ...node,
       tags,
-      like_count: Number(likeCount?.count || 0),
+      reactions: {
+        like: { count: Number(likeCount?.count || 0) },
+        interested: { count: Number(interestedCount?.count || 0) },
+        want_to_try: { count: Number(wantToTryCount?.count || 0) },
+      },
       comment_count: Number(commentCount?.count || 0),
     };
   }
@@ -177,22 +191,37 @@ export class NodeService {
           .where("node_tags.node_id", "=", node.id)
           .execute();
 
-        const likeCount = await this.db
-          .selectFrom("likes")
-          .select((eb) => eb.fn.countAll().as("count"))
-          .where("node_id", "=", node.id)
-          .executeTakeFirst();
-
-        const commentCount = await this.db
-          .selectFrom("comments")
-          .select((eb) => eb.fn.countAll().as("count"))
-          .where("node_id", "=", node.id)
-          .executeTakeFirst();
+        const [likeCount, interestedCount, wantToTryCount, commentCount] = await Promise.all([
+          this.db
+            .selectFrom("likes")
+            .select((eb) => eb.fn.countAll().as("count"))
+            .where("node_id", "=", node.id)
+            .executeTakeFirst(),
+          this.db
+            .selectFrom("interested")
+            .select((eb) => eb.fn.countAll().as("count"))
+            .where("node_id", "=", node.id)
+            .executeTakeFirst(),
+          this.db
+            .selectFrom("want_to_try")
+            .select((eb) => eb.fn.countAll().as("count"))
+            .where("node_id", "=", node.id)
+            .executeTakeFirst(),
+          this.db
+            .selectFrom("comments")
+            .select((eb) => eb.fn.countAll().as("count"))
+            .where("node_id", "=", node.id)
+            .executeTakeFirst(),
+        ]);
 
         return {
           ...node,
           tags,
-          like_count: Number(likeCount?.count || 0),
+          reactions: {
+            like: { count: Number(likeCount?.count || 0) },
+            interested: { count: Number(interestedCount?.count || 0) },
+            want_to_try: { count: Number(wantToTryCount?.count || 0) },
+          },
           comment_count: Number(commentCount?.count || 0),
         };
       }),
@@ -302,6 +331,7 @@ export class NodeService {
   }
 
   async getUserLikeStatus(nodeIds: string[], userId: string) {
+    if (nodeIds.length === 0) return {};
     const likes = await this.db
       .selectFrom("likes")
       .select("node_id")
@@ -311,5 +341,101 @@ export class NodeService {
 
     const likedNodeIds = new Set(likes.map((l) => l.node_id));
     return Object.fromEntries(nodeIds.map((id) => [id, likedNodeIds.has(id)]));
+  }
+
+  async toggleInterested(nodeId: string, userId: string) {
+    const existing = await this.db
+      .selectFrom("interested")
+      .select("node_id")
+      .where("node_id", "=", nodeId)
+      .where("user_id", "=", userId)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Remove interested
+      await this.db
+        .deleteFrom("interested")
+        .where("node_id", "=", nodeId)
+        .where("user_id", "=", userId)
+        .execute();
+      return { is_reacted: false };
+    } else {
+      // Add interested
+      await this.db
+        .insertInto("interested")
+        .values({
+          node_id: nodeId,
+          user_id: userId,
+          created_at: new Date().toISOString(),
+        })
+        .execute();
+      return { is_reacted: true };
+    }
+  }
+
+  async toggleWantToTry(nodeId: string, userId: string) {
+    const existing = await this.db
+      .selectFrom("want_to_try")
+      .select("node_id")
+      .where("node_id", "=", nodeId)
+      .where("user_id", "=", userId)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Remove want_to_try
+      await this.db
+        .deleteFrom("want_to_try")
+        .where("node_id", "=", nodeId)
+        .where("user_id", "=", userId)
+        .execute();
+      return { is_reacted: false };
+    } else {
+      // Add want_to_try
+      await this.db
+        .insertInto("want_to_try")
+        .values({
+          node_id: nodeId,
+          user_id: userId,
+          created_at: new Date().toISOString(),
+        })
+        .execute();
+      return { is_reacted: true };
+    }
+  }
+
+  async getUserInterestedStatus(nodeIds: string[], userId: string) {
+    if (nodeIds.length === 0) return {};
+    const rows = await this.db
+      .selectFrom("interested")
+      .select("node_id")
+      .where("node_id", "in", nodeIds)
+      .where("user_id", "=", userId)
+      .execute();
+
+    const interestedNodeIds = new Set(rows.map((r) => r.node_id));
+    return Object.fromEntries(nodeIds.map((id) => [id, interestedNodeIds.has(id)]));
+  }
+
+  async getUserWantToTryStatus(nodeIds: string[], userId: string) {
+    if (nodeIds.length === 0) return {};
+    const rows = await this.db
+      .selectFrom("want_to_try")
+      .select("node_id")
+      .where("node_id", "in", nodeIds)
+      .where("user_id", "=", userId)
+      .execute();
+
+    const wantToTryNodeIds = new Set(rows.map((r) => r.node_id));
+    return Object.fromEntries(nodeIds.map((id) => [id, wantToTryNodeIds.has(id)]));
+  }
+
+  async getReactionCount(nodeId: string, reactionType: "like" | "interested" | "want_to_try") {
+    const table = reactionType === "like" ? "likes" : reactionType;
+    const result = await this.db
+      .selectFrom(table)
+      .select((eb) => eb.fn.countAll().as("count"))
+      .where("node_id", "=", nodeId)
+      .executeTakeFirst();
+    return Number(result?.count || 0);
   }
 }


### PR DESCRIPTION
ノードに「気になる」と「やってみたい」のリアクション機能を追加。
- 新しいテーブル（interested, want_to_try）の追加
- リアクションのトグルエンドポイント追加
- ノード取得時にリアクション情報を含めるように変更
- 既存のlike機能とともに統一的なreactionsオブジェクトとして返却