### PR TITLE
refactor(infra): consolidate to single worker inspirehub-api

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -49,15 +49,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply DB --remote --env develop
-          workingDirectory: apps/api
-
-      - name: Set Worker Secrets
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: secret list --env develop
+          command: d1 migrations apply DB --remote
           workingDirectory: apps/api
 
       - name: Deploy to Cloudflare Workers
@@ -65,7 +57,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env develop --var GOOGLE_CLIENT_ID:${{ secrets.GOOGLE_CLIENT_ID }} --var GOOGLE_CLIENT_SECRET:${{ secrets.GOOGLE_CLIENT_SECRET }}
+          command: deploy --var GOOGLE_CLIENT_ID:${{ secrets.GOOGLE_CLIENT_ID }} --var GOOGLE_CLIENT_SECRET:${{ secrets.GOOGLE_CLIENT_SECRET }}
           workingDirectory: apps/api
           secrets: |
             JWT_ACCESS_SECRET

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: Update wrangler.jsonc with Configuration
         run: |
-          # wrangler.jsoncのdevelop環境設定を更新
           cat > apps/api/wrangler.jsonc << EOF
           {
             "\$schema": "node_modules/wrangler/config-schema.json",
@@ -130,41 +129,25 @@ jobs:
             "compatibility_date": "2024-09-23",
             "compatibility_flags": ["nodejs_compat_v2"],
 
-            // ローカル開発用のデフォルトD1設定
-            "d1_databases": [
+            "routes": [
               {
-                "binding": "DB",
-                "database_name": "inspirehub",
-                "database_id": "local-inspirehub"
+                "pattern": "api.inspirehub.wtnqk.org/*",
+                "zone_id": "${{ secrets.CLOUDFLARE_ZONE_ID }}"
               }
             ],
 
-            // ローカル開発用の環境変数
-            "vars": {
-              "CLIENT_URL": "http://localhost:5173"
-            },
-
-            // develop環境（本番）
-            "env": {
-              "develop": {
-                "routes": [
-                  {
-                    "pattern": "api.inspirehub.wtnqk.org/*",
-                    "zone_id": "${{ secrets.CLOUDFLARE_ZONE_ID }}"
-                  }
-                ],
-                "d1_databases": [
-                  {
-                    "binding": "DB",
-                    "database_name": "${{ steps.tf_outputs.outputs.d1_database_name }}",
-                    "database_id": "${{ steps.tf_outputs.outputs.d1_database_id }}"
-                  }
-                ],
-                "vars": {
-                  "ENVIRONMENT": "develop",
-                  "CLIENT_URL": "${{ secrets.CLIENT_URL }}"
-                }
+            "d1_databases": [
+              {
+                "binding": "DB",
+                "database_name": "${{ steps.tf_outputs.outputs.d1_database_name }}",
+                "database_id": "${{ steps.tf_outputs.outputs.d1_database_id }}"
               }
+            ],
+
+            "vars": {
+              "ENVIRONMENT": "develop",
+              "CLIENT_URL": "${{ secrets.CLIENT_URL }}",
+              "API_URL": "https://api.inspirehub.wtnqk.org"
             }
           }
           EOF
@@ -247,7 +230,6 @@ jobs:
 
       - name: Update wrangler.jsonc with D1 Database ID
         run: |
-          # wrangler.jsoncのdevelop環境にdatabase_idを設定
           cat > apps/api/wrangler.jsonc << EOF
           {
             "\$schema": "node_modules/wrangler/config-schema.json",
@@ -256,41 +238,25 @@ jobs:
             "compatibility_date": "2024-09-23",
             "compatibility_flags": ["nodejs_compat_v2"],
 
-            // ローカル開発用のデフォルトD1設定
-            "d1_databases": [
+            "routes": [
               {
-                "binding": "DB",
-                "database_name": "inspirehub",
-                "database_id": "local-inspirehub"
+                "pattern": "api.inspirehub.wtnqk.org/*",
+                "zone_id": "${{ secrets.CLOUDFLARE_ZONE_ID }}"
               }
             ],
 
-            // ローカル開発用の環境変数
-            "vars": {
-              "CLIENT_URL": "http://localhost:5173"
-            },
-
-            // develop環境（本番）
-            "env": {
-              "develop": {
-                "routes": [
-                  {
-                    "pattern": "api.inspirehub.wtnqk.org/*",
-                    "zone_id": "${{ secrets.CLOUDFLARE_ZONE_ID }}"
-                  }
-                ],
-                "d1_databases": [
-                  {
-                    "binding": "DB",
-                    "database_name": "${{ steps.tf_outputs.outputs.d1_database_name }}",
-                    "database_id": "${{ steps.tf_outputs.outputs.d1_database_id }}"
-                  }
-                ],
-                "vars": {
-                  "ENVIRONMENT": "develop",
-                  "CLIENT_URL": "${{ secrets.CLIENT_URL }}"
-                }
+            "d1_databases": [
+              {
+                "binding": "DB",
+                "database_name": "${{ steps.tf_outputs.outputs.d1_database_name }}",
+                "database_id": "${{ steps.tf_outputs.outputs.d1_database_id }}"
               }
+            ],
+
+            "vars": {
+              "ENVIRONMENT": "develop",
+              "CLIENT_URL": "${{ secrets.CLIENT_URL }}",
+              "API_URL": "https://api.inspirehub.wtnqk.org"
             }
           }
           EOF

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -5,40 +5,24 @@
   "compatibility_date": "2024-09-23",
   "compatibility_flags": ["nodejs_compat_v2"],
 
-  // ローカル開発用のデフォルトD1設定
-  "d1_databases": [
+  "routes": [
     {
-      "binding": "DB",
-      "database_name": "inspirehub",
-      "database_id": "local-inspirehub"
+      "pattern": "api.inspirehub.wtnqk.org/*",
+      "zone_id": "b04f9b32997d6009031966d002e66551"
     }
   ],
 
-  // ローカル開発用の環境変数
-  "vars": {
-    "CLIENT_URL": "http://localhost:5173"
-  },
-
-  // develop環境（本番）
-  "env": {
-    "develop": {
-      "routes": [
-        {
-          "pattern": "api.inspirehub.wtnqk.org/*",
-          "zone_id": "b04f9b32997d6009031966d002e66551"
-        }
-      ],
-      "d1_databases": [
-        {
-          "binding": "DB",
-          "database_name": "inspirehub-d1",
-          "database_id": "17c33eda-5d8d-4166-a1ac-b2278ec834a5"
-        }
-      ],
-      "vars": {
-        "ENVIRONMENT": "develop",
-        "CLIENT_URL": "https://web.inspirehub.wtnqk.org"
-      }
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "inspirehub-d1",
+      "database_id": "17c33eda-5d8d-4166-a1ac-b2278ec834a5"
     }
+  ],
+
+  "vars": {
+    "ENVIRONMENT": "develop",
+    "CLIENT_URL": "https://web.inspirehub.wtnqk.org",
+    "API_URL": "https://api.inspirehub.wtnqk.org"
   }
 }


### PR DESCRIPTION
- Remove env.develop section from wrangler.jsonc, use root config
- Remove --env develop from deploy-api.yml
- Update terraform.yml templates to use flat config
- Worker name is now inspirehub-api (not inspirehub-api-develop)