### PR TITLE
fix(api): fix D1 kysely transaction error and token family id mismatch

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -89,16 +89,14 @@ auth.post(
     const accessToken = await generateAccessToken(user.id, user.email, c.env.JWT_ACCESS_SECRET);
 
     // Create token family for refresh token
-    const familyId = crypto.randomUUID();
     const jti = crypto.randomUUID();
+    const familyId = await createTokenFamily(db, user.id, jti);
     const refreshToken = await generateRefreshToken(
       user.id,
       familyId,
       jti,
       c.env.JWT_REFRESH_SECRET,
     );
-
-    await createTokenFamily(db, user.id, jti);
 
     // Set tokens in HttpOnly cookies
     setCookie(c, "refresh_token", refreshToken, {

--- a/apps/api/src/services/comment.ts
+++ b/apps/api/src/services/comment.ts
@@ -34,32 +34,30 @@ export class CommentService {
     const commentId = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    await this.db.transaction().execute(async (trx) => {
-      // Create comment
-      await trx
-        .insertInto("comments")
-        .values({
-          id: commentId,
-          node_id: params.node_id,
-          parent_id: params.parent_id || null,
-          author_id: params.author_id,
-          content: params.content,
-          created_at: now,
-          updated_at: now,
-        })
-        .execute();
+    // Create comment
+    await this.db
+      .insertInto("comments")
+      .values({
+        id: commentId,
+        node_id: params.node_id,
+        parent_id: params.parent_id || null,
+        author_id: params.author_id,
+        content: params.content,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
 
-      // Handle mentions if provided
-      if (params.mentions && params.mentions.length > 0) {
-        const mentionValues = params.mentions.map((userId) => ({
-          comment_id: commentId,
-          mentioned_user_id: userId,
-          created_at: now,
-        }));
+    // Handle mentions if provided
+    if (params.mentions && params.mentions.length > 0) {
+      const mentionValues = params.mentions.map((userId) => ({
+        comment_id: commentId,
+        mentioned_user_id: userId,
+        created_at: now,
+      }));
 
-        await trx.insertInto("comment_mentions").values(mentionValues).execute();
-      }
-    });
+      await this.db.insertInto("comment_mentions").values(mentionValues).execute();
+    }
 
     return commentId;
   }
@@ -166,34 +164,32 @@ export class CommentService {
   ) {
     const now = new Date().toISOString();
 
-    await this.db.transaction().execute(async (trx) => {
-      // Update comment
-      await trx
-        .updateTable("comments")
-        .set({
-          content: params.content,
-          updated_at: now,
-        })
-        .where("id", "=", id)
-        .execute();
+    // Update comment
+    await this.db
+      .updateTable("comments")
+      .set({
+        content: params.content,
+        updated_at: now,
+      })
+      .where("id", "=", id)
+      .execute();
 
-      // Update mentions if provided
-      if (params.mentions !== undefined) {
-        // Remove existing mentions
-        await trx.deleteFrom("comment_mentions").where("comment_id", "=", id).execute();
+    // Update mentions if provided
+    if (params.mentions !== undefined) {
+      // Remove existing mentions
+      await this.db.deleteFrom("comment_mentions").where("comment_id", "=", id).execute();
 
-        // Add new mentions
-        if (params.mentions.length > 0) {
-          const mentionValues = params.mentions.map((userId) => ({
-            comment_id: id,
-            mentioned_user_id: userId,
-            created_at: now,
-          }));
+      // Add new mentions
+      if (params.mentions.length > 0) {
+        const mentionValues = params.mentions.map((userId) => ({
+          comment_id: id,
+          mentioned_user_id: userId,
+          created_at: now,
+        }));
 
-          await trx.insertInto("comment_mentions").values(mentionValues).execute();
-        }
+        await this.db.insertInto("comment_mentions").values(mentionValues).execute();
       }
-    });
+    }
   }
 
   async delete(id: string) {

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -15,71 +15,69 @@ export class NodeService {
     const nodeId = crypto.randomUUID();
     const now = new Date().toISOString();
 
-    await this.db.transaction().execute(async (trx) => {
-      // Create node
-      await trx
-        .insertInto("nodes")
+    // Create node
+    await this.db
+      .insertInto("nodes")
+      .values({
+        id: nodeId,
+        type: params.type,
+        title: params.title,
+        content: params.content,
+        author_id: params.author_id,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    // Create edge if parentNodeId is provided
+    if (params.parentNodeId) {
+      await this.db
+        .insertInto("edges")
         .values({
-          id: nodeId,
-          type: params.type,
-          title: params.title,
-          content: params.content,
-          author_id: params.author_id,
+          id: crypto.randomUUID(),
+          source: params.parentNodeId,
+          target: nodeId,
           created_at: now,
           updated_at: now,
         })
         .execute();
+    }
 
-      // Create edge if parentNodeId is provided
-      if (params.parentNodeId) {
-        await trx
-          .insertInto("edges")
-          .values({
-            id: crypto.randomUUID(),
-            source: params.parentNodeId,
-            target: nodeId,
-            created_at: now,
-            updated_at: now,
-          })
-          .execute();
-      }
+    // Handle tags if provided
+    if (params.tags && params.tags.length > 0) {
+      for (const tagName of params.tags) {
+        // Upsert tag
+        let tagId = crypto.randomUUID();
+        const existingTag = await this.db
+          .selectFrom("tags")
+          .select("id")
+          .where("name", "=", tagName)
+          .executeTakeFirst();
 
-      // Handle tags if provided
-      if (params.tags && params.tags.length > 0) {
-        for (const tagName of params.tags) {
-          // Upsert tag
-          let tagId = crypto.randomUUID();
-          const existingTag = await trx
-            .selectFrom("tags")
-            .select("id")
-            .where("name", "=", tagName)
-            .executeTakeFirst();
-
-          if (existingTag) {
-            tagId = existingTag.id;
-          } else {
-            await trx
-              .insertInto("tags")
-              .values({
-                id: tagId,
-                name: tagName,
-                created_at: now,
-              })
-              .execute();
-          }
-
-          // Create node-tag relation
-          await trx
-            .insertInto("node_tags")
+        if (existingTag) {
+          tagId = existingTag.id;
+        } else {
+          await this.db
+            .insertInto("tags")
             .values({
-              node_id: nodeId,
-              tag_id: tagId,
+              id: tagId,
+              name: tagName,
               created_at: now,
             })
             .execute();
         }
+
+        // Create node-tag relation
+        await this.db
+          .insertInto("node_tags")
+          .values({
+            node_id: nodeId,
+            tag_id: tagId,
+            created_at: now,
+          })
+          .execute();
       }
-    });
+    }
 
     return nodeId;
   }
@@ -272,60 +270,58 @@ export class NodeService {
   ) {
     const now = new Date().toISOString();
 
-    await this.db.transaction().execute(async (trx) => {
-      // Update node
-      const updateData: Partial<NodesTable> = {
-        updated_at: now,
-      };
+    // Update node
+    const updateData: Partial<NodesTable> = {
+      updated_at: now,
+    };
 
-      if (params.title !== undefined) {
-        updateData.title = params.title;
-      }
+    if (params.title !== undefined) {
+      updateData.title = params.title;
+    }
 
-      if (params.content !== undefined) {
-        updateData.content = params.content;
-      }
+    if (params.content !== undefined) {
+      updateData.content = params.content;
+    }
 
-      await trx.updateTable("nodes").set(updateData).where("id", "=", id).execute();
+    await this.db.updateTable("nodes").set(updateData).where("id", "=", id).execute();
 
-      // Update tags if provided
-      if (params.tags !== undefined) {
-        // Remove existing tags
-        await trx.deleteFrom("node_tags").where("node_id", "=", id).execute();
+    // Update tags if provided
+    if (params.tags !== undefined) {
+      // Remove existing tags
+      await this.db.deleteFrom("node_tags").where("node_id", "=", id).execute();
 
-        // Add new tags
-        for (const tagName of params.tags) {
-          let tagId = crypto.randomUUID();
-          const existingTag = await trx
-            .selectFrom("tags")
-            .select("id")
-            .where("name", "=", tagName)
-            .executeTakeFirst();
+      // Add new tags
+      for (const tagName of params.tags) {
+        let tagId = crypto.randomUUID();
+        const existingTag = await this.db
+          .selectFrom("tags")
+          .select("id")
+          .where("name", "=", tagName)
+          .executeTakeFirst();
 
-          if (existingTag) {
-            tagId = existingTag.id;
-          } else {
-            await trx
-              .insertInto("tags")
-              .values({
-                id: tagId,
-                name: tagName,
-                created_at: now,
-              })
-              .execute();
-          }
-
-          await trx
-            .insertInto("node_tags")
+        if (existingTag) {
+          tagId = existingTag.id;
+        } else {
+          await this.db
+            .insertInto("tags")
             .values({
-              node_id: id,
-              tag_id: tagId,
+              id: tagId,
+              name: tagName,
               created_at: now,
             })
             .execute();
         }
+
+        await this.db
+          .insertInto("node_tags")
+          .values({
+            node_id: id,
+            tag_id: tagId,
+            created_at: now,
+          })
+          .execute();
       }
-    });
+    }
   }
 
   async delete(id: string) {


### PR DESCRIPTION
## Summary
- kysely-d1がtransactionをサポートしていないため、node/commentのcreate/updateで500エラーが発生していた。transaction wrapperを削除しsequential queriesに置き換えた
- auth/verifyでcreateTokenFamilyが内部生成するfamilyIdとJWTに埋め込むfamilyIdが別物だったため、refresh tokenの検証が常に失敗していた。DB作成→返り値をJWTに使用する順序に修正した