### PR TITLE
fix(api): support iOS Google Sign-In by allowing multiple audience client IDs

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -61,7 +61,10 @@ auth.post(
     const { id_token } = c.req.valid("json");
 
     // Verify Google ID Token
-    const googlePayload = await verifyGoogleIdToken(id_token, c.env.GOOGLE_CLIENT_ID);
+    const googlePayload = await verifyGoogleIdToken(id_token, [
+      c.env.GOOGLE_CLIENT_ID,
+      c.env.GOOGLE_IOS_CLIENT_ID,
+    ]);
 
     if (!googlePayload) {
       return c.json(

--- a/apps/api/src/services/google-auth.ts
+++ b/apps/api/src/services/google-auth.ts
@@ -94,7 +94,7 @@ async function importRsaPublicKey(jwk: JWK): Promise<CryptoKey> {
 
 export async function verifyGoogleIdToken(
   idToken: string,
-  clientId: string,
+  clientIds: string | string[],
 ): Promise<GoogleIdTokenPayload | null> {
   const parts = idToken.split(".");
   if (parts.length !== 3) {
@@ -150,8 +150,9 @@ export async function verifyGoogleIdToken(
     return null;
   }
 
-  // Validate audience
-  if (payload.aud !== clientId) {
+  // Validate audience (supports multiple client IDs for web/iOS/Android)
+  const allowedIds = Array.isArray(clientIds) ? clientIds : [clientIds];
+  if (!allowedIds.includes(payload.aud)) {
     return null;
   }
 

--- a/apps/api/src/types/bindings.ts
+++ b/apps/api/src/types/bindings.ts
@@ -13,6 +13,7 @@ export interface CloudflareBindings {
   // Secrets (set via wrangler secret put)
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
+  GOOGLE_IOS_CLIENT_ID: string;
   JWT_ACCESS_SECRET: string;
   JWT_REFRESH_SECRET: string;
   CLIENT_URL: string;


### PR DESCRIPTION
## Summary
- `verifyGoogleIdToken` の audience 検証を複数 Client ID 対応に変更
- `GOOGLE_IOS_CLIENT_ID` を環境変数に追加
- iOS アプリからの Google Sign-In で 401 エラーになる問題を修正

Closes #21
