### PR TITLE
feat(api): add search query parameter q to GET /nodes

### DIFF
--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -76,7 +76,7 @@ const ListNodesResponseSchema = type({
 const ReactionToggleResponseSchema = type({
   is_reacted: "boolean",
   count: "number",
-});;
+});
 
 const nodes = new Hono<HonoEnv>();
 
@@ -108,6 +108,7 @@ nodes.get(
       type: query.type,
       author_id: query.author_id,
       tag: query.tag,
+      q: query.q,
       limit: query.limit || 20,
       offset: query.offset || 0,
     });

--- a/apps/api/src/schemas/node.ts
+++ b/apps/api/src/schemas/node.ts
@@ -20,6 +20,7 @@ export const ListNodesQuerySchema = type({
   "type?": NodeType,
   "author_id?": "string",
   "tag?": "string",
+  "q?": "string",
   "limit?": "1 <= number <= 100",
   "offset?": "number >= 0",
 });

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -159,6 +159,7 @@ export class NodeService {
     type?: NodesTable["type"];
     author_id?: string;
     tag?: string;
+    q?: string;
     limit?: number;
     offset?: number;
   }) {
@@ -189,6 +190,13 @@ export class NodeService {
         .innerJoin("node_tags", "nodes.id", "node_tags.node_id")
         .innerJoin("tags", "node_tags.tag_id", "tags.id")
         .where("tags.name", "=", params.tag);
+    }
+
+    if (params?.q) {
+      const pattern = `%${params.q}%`;
+      query = query.where((eb) =>
+        eb.or([eb("nodes.title", "like", pattern), eb("nodes.content", "like", pattern)]),
+      );
     }
 
     query = query.orderBy("nodes.created_at", "desc");


### PR DESCRIPTION
## Summary
- `GET /nodes?q=keyword` でtitleとcontentの部分一致検索を追加
- `q` 未指定時は従来通り全件返却

Closes #24