### PR TITLE
feat(api): parentNodeレスポンスにtypeを追加

### DIFF
--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -9,6 +9,7 @@ import {
   CreateNodeSchema,
   UpdateNodeSchema,
   ListNodesQuerySchema,
+  NodeType,
   type CreateNodeInput,
   type UpdateNodeInput,
   type ListNodesQuery,
@@ -38,8 +39,8 @@ const ReactionsSchema = type({
 
 const ParentNodeSchema = type({
   id: "string",
+  type: NodeType,
   title: "string",
-  content: "string",
 });
 
 const NodeResponseSchema = type({

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -114,7 +114,7 @@ export class NodeService {
     const parentNode = await this.db
       .selectFrom("edges")
       .innerJoin("nodes", "edges.source", "nodes.id")
-      .select(["nodes.id", "nodes.title", "nodes.content"])
+      .select(["nodes.id", "nodes.type", "nodes.title"])
       .where("edges.target", "=", id)
       .executeTakeFirst();
 
@@ -224,7 +224,7 @@ export class NodeService {
         const parentNode = await this.db
           .selectFrom("edges")
           .innerJoin("nodes", "edges.source", "nodes.id")
-          .select(["nodes.id", "nodes.title", "nodes.content"])
+          .select(["nodes.id", "nodes.type", "nodes.title"])
           .where("edges.target", "=", node.id)
           .executeTakeFirst();
 


### PR DESCRIPTION
- parentNodeのselectカラムを `content` → `type` に変更
- OpenAPIスキーマ（ParentNodeSchema）も同様に修正
- ハードコードしていたtype定義を `NodeType` 定数に置き換え

Closes #8