### PR TITLE
feat(api): add PATCH /users/me for updating user name

### DIFF
--- a/apps/api/src/index.tsx
+++ b/apps/api/src/index.tsx
@@ -9,6 +9,7 @@ import auth from "./routes/auth";
 import nodes from "./routes/nodes";
 import comments from "./routes/comments";
 import tags from "./routes/tags";
+import users from "./routes/users";
 import type { HonoEnv } from "./types/bindings";
 
 const app = new Hono<HonoEnv>();
@@ -23,6 +24,7 @@ app.route("/auth", auth);
 app.route("/nodes", nodes);
 app.route("/comments", comments);
 app.route("/tags", tags);
+app.route("/users", users);
 
 // Health check
 app.get("/", (c) => {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import { describeRoute, resolver, validator } from "hono-openapi";
+import type { HonoEnv } from "../types/bindings";
+import { updateUserName } from "../services/user";
+import { createDb } from "../lib/db";
+import { authMiddleware } from "../middleware/auth";
+import { UpdateMeBodySchema, UpdateMeResponseSchema, ErrorResponseSchema } from "../schemas/auth";
+
+const users = new Hono<HonoEnv>();
+
+// PATCH /users/me - Update current user name
+users.patch(
+  "/me",
+  describeRoute({
+    tags: ["Users"],
+    summary: "ユーザー名更新",
+    description: "認証済みユーザーの表示名を更新",
+    security: [{ Bearer: [] }],
+    responses: {
+      200: {
+        description: "更新成功",
+        content: {
+          "application/json": {
+            schema: resolver(UpdateMeResponseSchema),
+          },
+        },
+      },
+      401: {
+        description: "認証エラー",
+        content: {
+          "application/json": {
+            schema: resolver(ErrorResponseSchema),
+          },
+        },
+      },
+    },
+  }),
+  authMiddleware,
+  validator("json", UpdateMeBodySchema),
+  async (c) => {
+    const userId = c.get("userId");
+    if (!userId) {
+      return c.json(
+        {
+          success: false as const,
+          error: { code: "UNAUTHORIZED", message: "Not authenticated" },
+        },
+        401,
+      );
+    }
+
+    const { name } = c.req.valid("json");
+    const db = createDb(c.env.DB);
+    const user = await updateUserName(db, userId, name);
+
+    if (!user) {
+      return c.json(
+        {
+          success: false as const,
+          error: { code: "USER_NOT_FOUND", message: "User not found" },
+        },
+        404,
+      );
+    }
+
+    return c.json({ user });
+  },
+);
+
+export default users;

--- a/apps/api/src/schemas/auth.ts
+++ b/apps/api/src/schemas/auth.ts
@@ -52,6 +52,15 @@ export const GetMeResponseSchema = type({
   user: UserSchema,
 });
 
+// PATCH /auth/me
+export const UpdateMeBodySchema = type({
+  name: "string > 0",
+});
+
+export const UpdateMeResponseSchema = type({
+  user: UserSchema,
+});
+
 // POST /auth/logout
 export const LogoutResponseSchema = type({
   success: "true",

--- a/apps/api/src/services/user.ts
+++ b/apps/api/src/services/user.ts
@@ -90,6 +90,23 @@ export async function updateUser(
   return findUserById(db, id);
 }
 
+export async function updateUserName(
+  db: Kysely<Database>,
+  id: string,
+  name: string,
+): Promise<User | null> {
+  await db
+    .updateTable("users")
+    .set({
+      name,
+      updated_at: new Date().toISOString(),
+    })
+    .where("id", "=", id)
+    .execute();
+
+  return findUserById(db, id);
+}
+
 export async function findOrCreateUser(
   db: Kysely<Database>,
   params: {


### PR DESCRIPTION
- `PATCH /users/me` エンドポイントを新設（`{ name: string }` で表示名を更新）
- `/users` ルートを新設し、プロフィール操作を `/auth` から分離
- name更新専用の `updateUserName` メソッドを追加（`updateUser` はOAuth同期用に維持）

Closes #9