### PR TITLE
feat(api): add optionalAuthMiddleware for unauthenticated GET access 

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -23,3 +23,30 @@ export const authMiddleware = createMiddleware<HonoEnv>(async (c, next) => {
     await next();
   });
 });
+
+// Optional JWT authentication middleware
+// Sets userId/userEmail if a valid token is present, but does not reject unauthenticated requests
+export const optionalAuthMiddleware = createMiddleware<HonoEnv>(async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    await next();
+    return;
+  }
+
+  try {
+    const jwtMiddleware = jwt({
+      secret: c.env.JWT_ACCESS_SECRET,
+      alg: "HS256",
+    });
+
+    await jwtMiddleware(c, async () => {
+      const payload = c.get("jwtPayload") as AccessTokenPayload;
+      c.set("userId", payload.sub);
+      c.set("userEmail", payload.email);
+    });
+  } catch {
+    // Invalid token — continue as unauthenticated
+  }
+
+  await next();
+});

--- a/apps/api/src/routes/nodes.test.ts
+++ b/apps/api/src/routes/nodes.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { Hono } from "hono";
+import { sign } from "hono/jwt";
 import nodeRoutes from "./nodes";
 import { mockEnv } from "../test/mock-env";
 
@@ -42,6 +43,80 @@ describe("Node Routes", () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  test("GET /nodes with valid token should set userId context", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await sign(
+      { sub: "test-user-id", email: "test@example.com", type: "access", iat: now, exp: now + 900 },
+      mockEnv.JWT_ACCESS_SECRET,
+      "HS256",
+    );
+
+    const res = await app.request(
+      "/nodes",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { nodes: unknown[] };
+    expect(Array.isArray(data.nodes)).toBe(true);
+  });
+
+  test("GET /nodes with invalid token should still return 200", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes",
+      {
+        method: "GET",
+        headers: { Authorization: "Bearer invalid-token" },
+      },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { nodes: unknown[] };
+    expect(Array.isArray(data.nodes)).toBe(true);
+  });
+
+  test("GET /nodes with expired token should still return 200", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await sign(
+      {
+        sub: "test-user-id",
+        email: "test@example.com",
+        type: "access",
+        iat: now - 1800,
+        exp: now - 900,
+      },
+      mockEnv.JWT_ACCESS_SECRET,
+      "HS256",
+    );
+
+    const res = await app.request(
+      "/nodes",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { nodes: unknown[] };
+    expect(Array.isArray(data.nodes)).toBe(true);
   });
 
   test("GET /nodes/:id should return 404 for non-existent node", async () => {

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -88,6 +88,7 @@ nodes.get(
     tags: ["Nodes"],
     summary: "ノード一覧取得",
     description: "ノードの一覧を取得（フィルタオプション付き）",
+    security: [{ Bearer: [] }, {}],
     responses: {
       200: {
         description: "ノード一覧",
@@ -162,6 +163,7 @@ nodes.get(
     tags: ["Nodes"],
     summary: "ノード詳細取得",
     description: "IDを指定してノードの詳細情報を取得",
+    security: [{ Bearer: [] }, {}],
     responses: {
       200: {
         description: "ノード詳細",

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -4,7 +4,7 @@ import type { HonoEnv } from "../types/bindings";
 import { createDb } from "../lib/db";
 import { NodeService } from "../services/node";
 import { CommentService } from "../services/comment";
-import { authMiddleware } from "../middleware/auth";
+import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth";
 import {
   CreateNodeSchema,
   UpdateNodeSchema,
@@ -99,6 +99,7 @@ nodes.get(
       },
     },
   }),
+  optionalAuthMiddleware,
   validator("query", ListNodesQuerySchema),
   async (c) => {
     const query = c.req.valid("query") as ListNodesQuery;
@@ -115,25 +116,18 @@ nodes.get(
     });
 
     // Get user's reaction statuses if authenticated
-    const authHeader = c.req.header("Authorization");
+    const userId = c.get("userId");
     let likeStatuses: Record<string, boolean> = {};
     let interestedStatuses: Record<string, boolean> = {};
     let wantToTryStatuses: Record<string, boolean> = {};
 
-    if (authHeader) {
-      try {
-        const userId = c.get("userId");
-        if (userId) {
-          const nodeIds = nodesList.map((n) => n.id);
-          [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
-            nodeService.getUserLikeStatus(nodeIds, userId),
-            nodeService.getUserInterestedStatus(nodeIds, userId),
-            nodeService.getUserWantToTryStatus(nodeIds, userId),
-          ]);
-        }
-      } catch {
-        // Optional auth, ignore errors
-      }
+    if (userId) {
+      const nodeIds = nodesList.map((n) => n.id);
+      [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
+        nodeService.getUserLikeStatus(nodeIds, userId),
+        nodeService.getUserInterestedStatus(nodeIds, userId),
+        nodeService.getUserWantToTryStatus(nodeIds, userId),
+      ]);
     }
 
     const nodesWithReactionStatus = nodesList.map((node) => ({
@@ -187,6 +181,7 @@ nodes.get(
       },
     },
   }),
+  optionalAuthMiddleware,
   async (c) => {
     const id = c.req.param("id");
     const db = createDb(c.env.DB);
@@ -205,26 +200,20 @@ nodes.get(
     }
 
     // Check user's reaction statuses
+    const userId = c.get("userId");
     let likeStatus = false;
     let interestedStatus = false;
     let wantToTryStatus = false;
-    const authHeader = c.req.header("Authorization");
-    if (authHeader) {
-      try {
-        const userId = c.get("userId");
-        if (userId) {
-          const [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
-            nodeService.getUserLikeStatus([id], userId),
-            nodeService.getUserInterestedStatus([id], userId),
-            nodeService.getUserWantToTryStatus([id], userId),
-          ]);
-          likeStatus = likeStatuses[id] || false;
-          interestedStatus = interestedStatuses[id] || false;
-          wantToTryStatus = wantToTryStatuses[id] || false;
-        }
-      } catch {
-        // Optional auth, ignore errors
-      }
+
+    if (userId) {
+      const [likeStatuses, interestedStatuses, wantToTryStatuses] = await Promise.all([
+        nodeService.getUserLikeStatus([id], userId),
+        nodeService.getUserInterestedStatus([id], userId),
+        nodeService.getUserWantToTryStatus([id], userId),
+      ]);
+      likeStatus = likeStatuses[id] || false;
+      interestedStatus = interestedStatuses[id] || false;
+      wantToTryStatus = wantToTryStatuses[id] || false;
     }
 
     return c.json({


### PR DESCRIPTION
## Summary
- `optionalAuthMiddleware` を新設し、JWTトークンがあれば検証してユーザー情報をセット、なければそのまま続行するミドルウェアを追加
- `GET /nodes`, `GET /nodes/:id` に適用し、手動の `Authorization` ヘッダーチェックを置き換え
- 認証済みユーザーの `is_reacted` が常に `false` になっていたバグを修正

## Background
Apple App Store Review Guideline 5.1.1(v) により、閲覧機能はログインなしで利用可能にする必要がある。既存の GET エンドポイントは `authMiddleware` 未適用で未認証アクセス自体は可能だったが、`userId` がコンテキストにセットされないため `is_reacted` が常に `false` になるバグがあった。

## Changes
- `apps/api/src/middleware/auth.ts` — `optionalAuthMiddleware` 追加
- `apps/api/src/routes/nodes.ts` — GET /nodes, GET /nodes/:id にミドルウェア適用、手動ヘッダーチェック削除
- `apps/api/src/routes/nodes.test.ts` — 有効トークン/無効トークン/期限切れトークンの3ケース追加

Closes #27