### PR TITLE
fix(api): クエリパラメータ limit/offset の文字列→数値変換

### DIFF
--- a/apps/api/src/routes/comments.test.ts
+++ b/apps/api/src/routes/comments.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, describe } from "bun:test";
+import { Hono } from "hono";
+import nodeRoutes from "./nodes";
+import { mockEnv } from "../test/mock-env";
+
+describe("Comment Routes - Query Parameter Coercion", () => {
+  test("GET /nodes/:nodeId/comments with string limit/offset should return 200 or 404", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes/some-node-id/comments?limit=50&offset=0",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    // 404 because node doesn't exist, but not 400 (validation passed)
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /nodes/:nodeId/comments with non-numeric limit should return 400", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes/some-node-id/comments?limit=abc",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/nodes.test.ts
+++ b/apps/api/src/routes/nodes.test.ts
@@ -119,6 +119,47 @@ describe("Node Routes", () => {
     expect(Array.isArray(data.nodes)).toBe(true);
   });
 
+  test("GET /nodes with string limit/offset should return 200", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes?limit=20&offset=0",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { nodes: unknown[] };
+    expect(Array.isArray(data.nodes)).toBe(true);
+  });
+
+  test("GET /nodes with non-numeric limit should return 400", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes?limit=abc",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("GET /nodes with out-of-range limit should return 400", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request(
+      "/nodes?limit=0",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
   test("GET /nodes/:id should return 404 for non-existent node", async () => {
     const app = new Hono();
     app.route("/nodes", nodeRoutes);

--- a/apps/api/src/routes/tags.test.ts
+++ b/apps/api/src/routes/tags.test.ts
@@ -1,0 +1,58 @@
+import { test, expect, describe } from "bun:test";
+import { Hono } from "hono";
+import tagRoutes from "./tags";
+import { mockEnv } from "../test/mock-env";
+
+describe("Tag Routes - Query Parameter Coercion", () => {
+  test("GET /tags with string limit/offset should return 200", async () => {
+    const app = new Hono();
+    app.route("/tags", tagRoutes);
+
+    const res = await app.request(
+      "/tags?limit=10&offset=0",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  test("GET /tags with non-numeric limit should return 400", async () => {
+    const app = new Hono();
+    app.route("/tags", tagRoutes);
+
+    const res = await app.request(
+      "/tags?limit=abc",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("GET /tags/suggest with string limit should return 200", async () => {
+    const app = new Hono();
+    app.route("/tags", tagRoutes);
+
+    const res = await app.request(
+      "/tags/suggest?q=test&limit=5",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  test("GET /tags/suggest with non-numeric limit should return 400", async () => {
+    const app = new Hono();
+    app.route("/tags", tagRoutes);
+
+    const res = await app.request(
+      "/tags/suggest?q=test&limit=abc",
+      { method: "GET" },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/schemas/comment.ts
+++ b/apps/api/src/schemas/comment.ts
@@ -12,8 +12,8 @@ export const UpdateCommentSchema = type({
 });
 
 export const ListCommentsQuerySchema = type({
-  "limit?": "1 <= number <= 100",
-  "offset?": "number >= 0",
+  "limit?": type("string.numeric.parse").to("1 <= number <= 100"),
+  "offset?": type("string.numeric.parse").to("number >= 0"),
 });
 
 // Response schemas for OpenAPI

--- a/apps/api/src/schemas/node.ts
+++ b/apps/api/src/schemas/node.ts
@@ -21,8 +21,8 @@ export const ListNodesQuerySchema = type({
   "author_id?": "string",
   "tag?": "string",
   "q?": "string",
-  "limit?": "1 <= number <= 100",
-  "offset?": "number >= 0",
+  "limit?": type("string.numeric.parse").to("1 <= number <= 100"),
+  "offset?": type("string.numeric.parse").to("number >= 0"),
 });
 
 export type CreateNodeInput = typeof CreateNodeSchema.infer;

--- a/apps/api/src/schemas/tag.ts
+++ b/apps/api/src/schemas/tag.ts
@@ -10,13 +10,13 @@ export const UpdateTagSchema = type({
 
 export const ListTagsQuerySchema = type({
   "search?": "string",
-  "limit?": "1 <= number <= 100",
-  "offset?": "number >= 0",
+  "limit?": type("string.numeric.parse").to("1 <= number <= 100"),
+  "offset?": type("string.numeric.parse").to("number >= 0"),
 });
 
 export const TagSuggestQuerySchema = type({
   q: "string > 0",
-  "limit?": "1 <= number <= 10",
+  "limit?": type("string.numeric.parse").to("1 <= number <= 10"),
 });
 
 // Response schemas for OpenAPI


### PR DESCRIPTION
## Summary
- クエリパラメータ `limit`/`offset` が文字列で送信された際に 400 エラーになるバグを修正
- arktype の `string.numeric.parse` モーフで文字列→数値の自動変換を追加
- `node.ts`, `comment.ts`, `tag.ts` の全スキーマを修正

## Changed Files
- `apps/api/src/schemas/node.ts` — `ListNodesQuerySchema` の limit/offset
- `apps/api/src/schemas/comment.ts` — `ListCommentsQuerySchema` の limit/offset
- `apps/api/src/schemas/tag.ts` — `ListTagsQuerySchema` の limit/offset, `TagSuggestQuerySchema` の limit