### PR TITLE
fix(api): fix #32 #33 #34 — content missing, parent_node null, OpenAPI 500

### DIFF
--- a/apps/api/src/lib/validators.ts
+++ b/apps/api/src/lib/validators.ts
@@ -1,0 +1,15 @@
+import { validator } from "hono/validator";
+import { type } from "arktype";
+
+export function arktypeQueryValidator<T>(schema: (input: unknown) => T | InstanceType<typeof type.errors>) {
+  return validator("query", (value, c) => {
+    const result = schema(value);
+    if (result instanceof type.errors) {
+      return c.json(
+        { success: false, error: { code: "VALIDATION_ERROR", message: result.summary } },
+        400,
+      );
+    }
+    return result as T;
+  });
+}

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import type { HonoEnv } from "../types/bindings";
 import { createDb } from "../lib/db";
+import { arktypeQueryValidator } from "../lib/validators";
 import { NodeService } from "../services/node";
 import { CommentService } from "../services/comment";
 import { authMiddleware, optionalAuthMiddleware } from "../middleware/auth";
@@ -89,6 +90,14 @@ nodes.get(
     summary: "ノード一覧取得",
     description: "ノードの一覧を取得（フィルタオプション付き）",
     security: [{ Bearer: [] }, {}],
+    parameters: [
+      { name: "type", in: "query", required: false, schema: { type: "string", enum: ["issue", "idea", "project"] } },
+      { name: "author_id", in: "query", required: false, schema: { type: "string" } },
+      { name: "tag", in: "query", required: false, schema: { type: "string" } },
+      { name: "q", in: "query", required: false, schema: { type: "string" } },
+      { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "offset", in: "query", required: false, schema: { type: "integer", minimum: 0 } },
+    ],
     responses: {
       200: {
         description: "ノード一覧",
@@ -101,7 +110,7 @@ nodes.get(
     },
   }),
   optionalAuthMiddleware,
-  validator("query", ListNodesQuerySchema),
+  arktypeQueryValidator(ListNodesQuerySchema),
   async (c) => {
     const query = c.req.valid("query") as ListNodesQuery;
     const db = createDb(c.env.DB);
@@ -637,6 +646,10 @@ nodes.get(
     tags: ["Comments"],
     summary: "コメント一覧取得",
     description: "指定したノードのコメントをネストされたリプライと共に取得",
+    parameters: [
+      { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "offset", in: "query", required: false, schema: { type: "integer", minimum: 0 } },
+    ],
     responses: {
       200: {
         description: "コメント一覧",
@@ -656,7 +669,7 @@ nodes.get(
       },
     },
   }),
-  validator("query", ListCommentsQuerySchema),
+  arktypeQueryValidator(ListCommentsQuerySchema),
   async (c) => {
     const nodeId = c.req.param("nodeId");
     const query = c.req.valid("query") as ListCommentsQuery;

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import type { HonoEnv } from "../types/bindings";
 import { createDb } from "../lib/db";
+import { arktypeQueryValidator } from "../lib/validators";
 import { TagService } from "../services/tag";
 import { authMiddleware } from "../middleware/auth";
 import {
@@ -32,6 +33,11 @@ tags.get(
     tags: ["Tags"],
     summary: "タグ一覧取得",
     description: "すべてのタグを使用回数と共に取得",
+    parameters: [
+      { name: "search", in: "query", required: false, schema: { type: "string" } },
+      { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "offset", in: "query", required: false, schema: { type: "integer", minimum: 0 } },
+    ],
     responses: {
       200: {
         description: "タグ一覧",
@@ -43,7 +49,7 @@ tags.get(
       },
     },
   }),
-  validator("query", ListTagsQuerySchema),
+  arktypeQueryValidator(ListTagsQuerySchema),
   async (c) => {
     const query = c.req.valid("query") as ListTagsQuery;
     const db = createDb(c.env.DB);
@@ -100,6 +106,10 @@ tags.get(
     tags: ["Tags"],
     summary: "タグサジェスト",
     description: "部分入力に基づいてタグ候補を取得",
+    parameters: [
+      { name: "q", in: "query", required: true, schema: { type: "string", minLength: 1 } },
+      { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 10 } },
+    ],
     responses: {
       200: {
         description: "タグ候補",
@@ -111,7 +121,7 @@ tags.get(
       },
     },
   }),
-  validator("query", TagSuggestQuerySchema),
+  arktypeQueryValidator(TagSuggestQuerySchema),
   async (c) => {
     const query = c.req.valid("query") as TagSuggestQuery;
     const db = createDb(c.env.DB);
@@ -224,6 +234,10 @@ tags.get(
     tags: ["Tags"],
     summary: "タグ別ノード取得",
     description: "指定したタグを持つすべてのノードを取得",
+    parameters: [
+      { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+      { name: "offset", in: "query", required: false, schema: { type: "integer", minimum: 0 } },
+    ],
     responses: {
       200: {
         description: "タグ付きノード一覧",
@@ -243,7 +257,7 @@ tags.get(
       },
     },
   }),
-  validator("query", ListTagsQuerySchema),
+  arktypeQueryValidator(ListTagsQuerySchema),
   async (c) => {
     const name = c.req.param("name");
     const query = c.req.valid("query") as ListTagsQuery;

--- a/apps/api/src/schemas/node.ts
+++ b/apps/api/src/schemas/node.ts
@@ -7,7 +7,7 @@ export const CreateNodeSchema = type({
   title: "string > 0",
   content: "string",
   "tags?": "string[]",
-  "parentNodeId?": "string",
+  "parent_node_id?": "string",
 });
 
 export const UpdateNodeSchema = type({

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -10,7 +10,7 @@ export class NodeService {
     content: string;
     author_id: string;
     tags?: string[];
-    parentNodeId?: string;
+    parent_node_id?: string;
   }) {
     const nodeId = crypto.randomUUID();
     const now = new Date().toISOString();
@@ -29,13 +29,13 @@ export class NodeService {
       })
       .execute();
 
-    // Create edge if parentNodeId is provided
-    if (params.parentNodeId) {
+    // Create edge if parent_node_id is provided
+    if (params.parent_node_id) {
       await this.db
         .insertInto("edges")
         .values({
           id: crypto.randomUUID(),
-          source: params.parentNodeId,
+          source: params.parent_node_id,
           target: nodeId,
           created_at: now,
           updated_at: now,
@@ -170,6 +170,7 @@ export class NodeService {
         "nodes.id",
         "nodes.type",
         "nodes.title",
+        "nodes.content",
         "nodes.author_id",
         "nodes.created_at",
         "nodes.updated_at",


### PR DESCRIPTION
## Summary
- **#32**: `GET /nodes` の `content` 欠落 → select に追加
- **#33**: `parent_node` が常に null → `parentNodeId` を `parent_node_id` に修正
- **#34**: `/openapi.json` が 500 → morph型のクエリバリデーションを hono validator に切り替え
