### PR TITLE
feat(web): optimistic updates & login page redesign

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "clsx": "^2.1.1",
     "hono": "4.11.7",
     "lucide-react": "^0.544.0",
+    "motion": "^12.34.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.0.2",

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,7 +2,6 @@ import { Link, useMatchRoute } from "@tanstack/react-router";
 import { Home, Compass, User } from "lucide-react";
 import { UserMenu } from "./auth/UserMenu";
 import { useAuthStore } from "@/stores/auth";
-import { Button } from "./ui/button";
 
 const navLinks = [
   { to: "/", icon: Home, label: "ホーム" },
@@ -17,7 +16,7 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
-        <Link to="/" className="text-xl font-bold tracking-tight text-primary">
+        <Link to="/" className="text-xl font-bold tracking-tight text-foreground">
           InspireHub
         </Link>
 
@@ -43,15 +42,11 @@ export default function Header() {
           </nav>
         )}
 
-        <div>
-          {isAuthenticated ? (
+        {isAuthenticated && (
+          <div>
             <UserMenu />
-          ) : (
-            <Button variant="outline" size="sm" asChild>
-              <Link to="/login">ログイン</Link>
-            </Button>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/web/src/components/auth/GoogleLoginButton.tsx
@@ -1,10 +1,8 @@
 import { GoogleLogin, type CredentialResponse } from "@react-oauth/google";
-import { useNavigate } from "@tanstack/react-router";
 import { useAuthStore } from "@/stores/auth";
 import { env } from "@/env";
 
 export function GoogleLoginButton() {
-  const navigate = useNavigate();
   const { setAuth, setError, setLoading } = useAuthStore();
 
   const handleSuccess = async (response: CredentialResponse) => {
@@ -33,7 +31,6 @@ export function GoogleLoginButton() {
       const data = (await res.json()) as { user: Parameters<typeof setAuth>[0]; access_token: string };
 
       setAuth(data.user, data.access_token);
-      void navigate({ to: "/" });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Authentication failed");
     } finally {

--- a/apps/web/src/components/nodes/ReactionButtons.tsx
+++ b/apps/web/src/components/nodes/ReactionButtons.tsx
@@ -1,20 +1,5 @@
 import { Heart, Flame, Rocket } from "lucide-react";
-import type { InferResponseType } from "hono/client";
-import { api, handleResponse } from "@/lib/api";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-
-type ReactionToggleResponse = InferResponseType<(typeof api.nodes)[":id"]["like"]["$post"], 200>;
-
-interface ReactionStatus {
-  count: number;
-  is_reacted?: boolean;
-}
-
-interface Reactions {
-  like: ReactionStatus;
-  interested: ReactionStatus;
-  want_to_try: ReactionStatus;
-}
+import { useToggleReaction, type Reactions } from "@/hooks/use-toggle-reaction";
 
 interface ReactionButtonsProps {
   nodeId: string;
@@ -28,28 +13,8 @@ const reactionMeta = [
   { key: "want_to_try", icon: Rocket, label: "やってみたい" },
 ] as const;
 
-function getReactionFetcher(nodeId: string, type: keyof Reactions) {
-  const param = { id: nodeId };
-  if (type === "like") return () => api.nodes[":id"].like.$post({ param });
-  if (type === "interested") return () => api.nodes[":id"].interested.$post({ param });
-  return () => api.nodes[":id"]["want-to-try"].$post({ param });
-}
-
-async function toggleReaction(nodeId: string, type: keyof Reactions) {
-  const fetcher = getReactionFetcher(nodeId, type);
-  const res = await fetcher();
-  return handleResponse<ReactionToggleResponse>(res, fetcher);
-}
-
 export function ReactionButtons({ nodeId, reactions, variant = "compact" }: ReactionButtonsProps) {
-  const queryClient = useQueryClient();
-
-  const mutation = useMutation({
-    mutationFn: (type: keyof Reactions) => toggleReaction(nodeId, type),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["nodes"] });
-    },
-  });
+  const mutation = useToggleReaction(nodeId);
 
   if (variant === "compact") {
     return (
@@ -65,7 +30,6 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
                 e.stopPropagation();
                 mutation.mutate(key);
               }}
-              disabled={mutation.isPending}
               className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs active:scale-90 transition-transform ${
                 isActive
                   ? "bg-primary/15 text-primary"
@@ -94,7 +58,6 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
               e.stopPropagation();
               mutation.mutate(key);
             }}
-            disabled={mutation.isPending}
             className={`flex flex-col items-center active:scale-90 transition-transform ${
               isActive ? "text-primary" : "text-muted-foreground"
             }`}

--- a/apps/web/src/hooks/use-comments.ts
+++ b/apps/web/src/hooks/use-comments.ts
@@ -1,0 +1,189 @@
+import type { InferResponseType } from "hono/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, handleResponse } from "@/lib/api";
+import { useAuthStore } from "@/stores/auth";
+
+type CommentsListResponse = InferResponseType<
+  (typeof api.nodes)[":nodeId"]["comments"]["$get"],
+  200
+>;
+type CommentCreateResponse = InferResponseType<
+  (typeof api.nodes)[":nodeId"]["comments"]["$post"],
+  201
+>;
+type Comment = CommentsListResponse["comments"][number];
+
+function removeCommentById(comments: Comment[], id: string): Comment[] {
+  return comments.reduce<Comment[]>((acc, c) => {
+    if (c.id === id) return acc;
+    const filtered = { ...c };
+    if (c.replies && c.replies.length > 0) {
+      filtered.replies = removeCommentById(c.replies as Comment[], id) as typeof c.replies;
+    }
+    acc.push(filtered);
+    return acc;
+  }, []);
+}
+
+function updateCommentContent(comments: Comment[], id: string, content: string): Comment[] {
+  return comments.map((c) => {
+    if (c.id === id) return { ...c, content };
+    if (c.replies && c.replies.length > 0) {
+      return {
+        ...c,
+        replies: updateCommentContent(c.replies as Comment[], id, content) as typeof c.replies,
+      };
+    }
+    return c;
+  });
+}
+
+export function usePostComment(nodeId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (content: string) => {
+      const fetcher = () =>
+        api.nodes[":nodeId"].comments.$post({ param: { nodeId }, json: { content } });
+      const res = await fetcher();
+      return handleResponse<CommentCreateResponse>(res, fetcher);
+    },
+    onMutate: async (content: string) => {
+      await queryClient.cancelQueries({ queryKey: ["nodes", nodeId, "comments"] });
+
+      const snapshot = queryClient.getQueryData<CommentsListResponse>([
+        "nodes",
+        nodeId,
+        "comments",
+      ]);
+
+      const user = useAuthStore.getState().user;
+      const tempComment = {
+        id: crypto.randomUUID(),
+        content,
+        author_id: user?.id ?? "",
+        author_name: user?.name ?? null,
+        author_picture: user?.picture ?? null,
+        created_at: new Date().toISOString(),
+        replies: [],
+      } as unknown as Comment;
+
+      queryClient.setQueryData<CommentsListResponse>(
+        ["nodes", nodeId, "comments"],
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            comments: [...old.comments, tempComment],
+            total: old.total + 1,
+          };
+        },
+      );
+
+      return { snapshot };
+    },
+    onError: (_err, _content, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(["nodes", nodeId, "comments"], context.snapshot);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId, "comments"] });
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId] });
+    },
+  });
+}
+
+export function useUpdateComment(nodeId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ commentId, content }: { commentId: string; content: string }) => {
+      const fetcher = () =>
+        api.comments[":id"].$put({ param: { id: commentId }, json: { content } });
+      const res = await fetcher();
+      return handleResponse<InferResponseType<(typeof api.comments)[":id"]["$put"], 200>>(
+        res,
+        fetcher,
+      );
+    },
+    onMutate: async ({ commentId, content }) => {
+      await queryClient.cancelQueries({ queryKey: ["nodes", nodeId, "comments"] });
+
+      const snapshot = queryClient.getQueryData<CommentsListResponse>([
+        "nodes",
+        nodeId,
+        "comments",
+      ]);
+
+      queryClient.setQueryData<CommentsListResponse>(
+        ["nodes", nodeId, "comments"],
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            comments: updateCommentContent(old.comments, commentId, content),
+          };
+        },
+      );
+
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(["nodes", nodeId, "comments"], context.snapshot);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId, "comments"] });
+    },
+  });
+}
+
+export function useDeleteComment(nodeId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (commentId: string) => {
+      const fetcher = () => api.comments[":id"].$delete({ param: { id: commentId } });
+      const res = await fetcher();
+      return handleResponse<InferResponseType<(typeof api.comments)[":id"]["$delete"], 200>>(
+        res,
+        fetcher,
+      );
+    },
+    onMutate: async (commentId: string) => {
+      await queryClient.cancelQueries({ queryKey: ["nodes", nodeId, "comments"] });
+
+      const snapshot = queryClient.getQueryData<CommentsListResponse>([
+        "nodes",
+        nodeId,
+        "comments",
+      ]);
+
+      queryClient.setQueryData<CommentsListResponse>(
+        ["nodes", nodeId, "comments"],
+        (old) => {
+          if (!old) return old;
+          const filtered = removeCommentById(old.comments, commentId);
+          return {
+            ...old,
+            comments: filtered,
+            total: old.total - (old.comments.length - filtered.length),
+          };
+        },
+      );
+
+      return { snapshot };
+    },
+    onError: (_err, _commentId, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(["nodes", nodeId, "comments"], context.snapshot);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId, "comments"] });
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId] });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-toggle-reaction.ts
+++ b/apps/web/src/hooks/use-toggle-reaction.ts
@@ -1,0 +1,105 @@
+import type { InferResponseType } from "hono/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, handleResponse } from "@/lib/api";
+
+type ReactionToggleResponse = InferResponseType<
+  (typeof api.nodes)[":id"]["like"]["$post"],
+  200
+>;
+
+interface ReactionStatus {
+  count: number;
+  is_reacted?: boolean;
+}
+
+interface Reactions {
+  like: ReactionStatus;
+  interested: ReactionStatus;
+  want_to_try: ReactionStatus;
+}
+
+type ReactionType = keyof Reactions;
+
+function getReactionFetcher(nodeId: string, type: ReactionType) {
+  const param = { id: nodeId };
+  if (type === "like") return () => api.nodes[":id"].like.$post({ param });
+  if (type === "interested") return () => api.nodes[":id"].interested.$post({ param });
+  return () => api.nodes[":id"]["want-to-try"].$post({ param });
+}
+
+function updateReactionsInData(data: unknown, nodeId: string, type: ReactionType): boolean {
+  if (!data || typeof data !== "object") return false;
+
+  // NodeDetail shape: { id, reactions, ... }
+  const detail = data as Record<string, unknown>;
+  if (detail.id === nodeId && detail.reactions) {
+    const reactions = detail.reactions as Reactions;
+    const current = reactions[type];
+    const wasReacted = current.is_reacted ?? false;
+    reactions[type] = {
+      count: wasReacted ? current.count - 1 : current.count + 1,
+      is_reacted: !wasReacted,
+    };
+    return true;
+  }
+
+  // NodesListResponse shape: { nodes: [...], total }
+  if ("nodes" in detail && Array.isArray(detail.nodes)) {
+    for (const node of detail.nodes as Record<string, unknown>[]) {
+      if (node.id === nodeId && node.reactions) {
+        const reactions = node.reactions as Reactions;
+        const current = reactions[type];
+        const wasReacted = current.is_reacted ?? false;
+        reactions[type] = {
+          count: wasReacted ? current.count - 1 : current.count + 1,
+          is_reacted: !wasReacted,
+        };
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function useToggleReaction(nodeId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (type: ReactionType) => {
+      const fetcher = getReactionFetcher(nodeId, type);
+      const res = await fetcher();
+      return handleResponse<ReactionToggleResponse>(res, fetcher);
+    },
+    onMutate: async (type: ReactionType) => {
+      await queryClient.cancelQueries({ queryKey: ["nodes"] });
+
+      const snapshots: [readonly unknown[], unknown][] = [];
+      const allQueries = queryClient.getQueriesData<unknown>({ queryKey: ["nodes"] });
+
+      for (const [key, data] of allQueries) {
+        if (data == null) continue;
+        snapshots.push([key, structuredClone(data)]);
+        queryClient.setQueryData(key, (old: unknown) => {
+          if (old == null) return old;
+          const clone = structuredClone(old);
+          updateReactionsInData(clone, nodeId, type);
+          return clone;
+        });
+      }
+
+      return { snapshots };
+    },
+    onError: (_err, _type, context) => {
+      if (!context?.snapshots) return;
+      for (const [key, data] of context.snapshots) {
+        queryClient.setQueryData(key, data);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId] });
+    },
+  });
+}
+
+export type { Reactions, ReactionType, ReactionStatus };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  useMatchRoute,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { GoogleOAuthProvider } from "@react-oauth/google";
@@ -28,14 +29,21 @@ import "./styles.css";
 import reportWebVitals from "./reportWebVitals";
 import { env } from "./env";
 
-const rootRoute = createRootRoute({
-  component: () => (
+function RootComponent() {
+  const matchRoute = useMatchRoute();
+  const isLogin = matchRoute({ to: "/login" });
+
+  return (
     <>
-      <Header />
+      {!isLogin && <Header />}
       <Outlet />
       <TanStackRouterDevtools />
     </>
-  ),
+  );
+}
+
+const rootRoute = createRootRoute({
+  component: RootComponent,
 });
 
 const authenticatedLayout = createRoute({

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,28 +1,147 @@
-import { createRoute, type AnyRootRoute } from "@tanstack/react-router";
+import { useState, useEffect } from "react";
+import {
+  createRoute,
+  type AnyRootRoute,
+  useNavigate,
+} from "@tanstack/react-router";
+import { motion, AnimatePresence } from "motion/react";
 import { GoogleLoginButton } from "@/components/auth/GoogleLoginButton";
 import { useAuthStore } from "@/stores/auth";
-import { useEffect } from "react";
-import { useNavigate } from "@tanstack/react-router";
+
+const YARUO = `＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
+|　　　　　　　　　　　　　　　　　　　　　　　　　　|
+|　 ログインするお！　　　　　　　　　　　 　　|
+|　　　　　　　　　　　　　　　　　　　　　　　　　　|
+￣￣￣￣￣￣∨￣￣￣￣￣￣￣￣￣￣
+　　　　　　 ＿＿＿＿
+　　　　　／　　　　　　　＼
+　　　／　 ⌒　　　　⌒　　＼
+　／　　 （●）　（●）　　　　 ＼
+　|　　　　（__人__）　 　　　　　　|
+　＼　　　　　　　　　　　　　 ／
+　　ノ　　　　　　　　　　　　 ＼
+　／´　　　　　　　　　　　　　｜
+　|　　　ｌ　　　　　　　　 ｜`;
 
 function LoginPage() {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthStore();
+  const [wasAuthOnMount] = useState(isAuthenticated);
+  const [isTransitioning, setIsTransitioning] = useState(false);
 
   useEffect(() => {
     if (isAuthenticated) {
-      void navigate({ to: "/" });
+      if (wasAuthOnMount) {
+        void navigate({ to: "/" });
+      } else {
+        setIsTransitioning(true);
+      }
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, wasAuthOnMount, navigate]);
 
   return (
-    <div className="flex min-h-[80vh] items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 p-6">
-        <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-bold">Welcome</h1>
-          <p className="text-muted-foreground">Sign in to continue</p>
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background">
+      {/* Background orbs */}
+      <motion.div
+        className="pointer-events-none absolute -left-32 -top-24 h-[420px] w-[420px] rounded-full opacity-[0.15] blur-[100px]"
+        style={{ background: "#9ca3af" }}
+        animate={{ x: [0, 30, 0], y: [0, 20, 0], scale: [1, 1.1, 1] }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.div
+        className="pointer-events-none absolute -bottom-32 -right-24 h-[360px] w-[360px] rounded-full opacity-[0.12] blur-[100px]"
+        style={{ background: "#a1a1aa" }}
+        animate={{ x: [0, -20, 0], y: [0, -30, 0], scale: [1, 1.15, 1] }}
+        transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.div
+        className="pointer-events-none absolute -right-16 top-1/4 h-[240px] w-[240px] rounded-full opacity-[0.10] blur-[80px]"
+        style={{ background: "#d4d4d8" }}
+        animate={{ x: [0, -15, 0], y: [0, 25, 0] }}
+        transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      <AnimatePresence>
+        {isTransitioning && (
+          <motion.div
+            className="pointer-events-none absolute inset-0 z-10"
+            style={{ backgroundColor: "#d4d4d8" }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0.15, 0] }}
+            transition={{ duration: 0.7, ease: "easeOut" }}
+          />
+        )}
+      </AnimatePresence>
+
+      <motion.div
+        className="w-full max-w-lg px-6"
+        animate={
+          isTransitioning
+            ? {
+                opacity: [1, 1, 0],
+                scale: [1, 1.06, 1.2],
+                filter: [
+                  "blur(0px) brightness(1)",
+                  "blur(0px) brightness(1.4)",
+                  "blur(20px) brightness(1.4)",
+                ],
+              }
+            : { opacity: 1, scale: 1, filter: "blur(0px) brightness(1)" }
+        }
+        transition={{ duration: isTransitioning ? 0.8 : 0 }}
+        onAnimationComplete={() => {
+          if (isTransitioning) void navigate({ to: "/" });
+        }}
+      >
+        {/* Brand + Yaruo */}
+        <div className="flex items-end justify-center gap-6">
+          {/* Brand */}
+          <motion.div
+            className="shrink-0 select-none"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.2 }}
+          >
+            <h1 className="text-5xl font-bold tracking-tight text-foreground">
+              Inspire
+              <br />
+              Hub
+            </h1>
+          </motion.div>
+
+          {/* Yaruo */}
+          <motion.pre
+            className="shrink-0 select-none text-[11px] leading-[1.2] text-foreground/80"
+            style={{
+              fontFamily: "'Mona','IPAMonaPGothic','MS PGothic',monospace",
+            }}
+            initial={{ opacity: 0, x: 12 }}
+            animate={{ opacity: 1, x: 0, y: [0, -2, 0] }}
+            transition={{
+              opacity: { duration: 0.5, delay: 0.5 },
+              x: { duration: 0.5, delay: 0.5 },
+              y: {
+                duration: 3,
+                repeat: Infinity,
+                ease: "easeInOut",
+                delay: 0.5,
+              },
+            }}
+          >
+            {YARUO}
+          </motion.pre>
         </div>
-        <GoogleLoginButton />
-      </div>
+
+        {/* Login button */}
+        <motion.div
+          className="mt-10 flex justify-center"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.9 }}
+        >
+          <GoogleLoginButton />
+        </motion.div>
+      </motion.div>
     </div>
   );
 }

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { api, handleResponse } from "@/lib/api";
 import { useAuthStore } from "@/stores/auth";
+import { usePostComment, useUpdateComment, useDeleteComment } from "@/hooks/use-comments";
 import { ReactionButtons } from "@/components/nodes/ReactionButtons";
 import { TagInput } from "@/components/nodes/TagInput";
 import { Button } from "@/components/ui/button";
@@ -36,10 +37,6 @@ type CommentsListResponse = InferResponseType<
   200
 >;
 type NodeCreateResponse = InferResponseType<(typeof api.nodes)["$post"], 201>;
-type CommentCreateResponse = InferResponseType<
-  (typeof api.nodes)[":nodeId"]["comments"]["$post"],
-  201
->;
 type MessageResponse = InferResponseType<(typeof api.nodes)[":id"]["$put"], 200>;
 type Comment = CommentsListResponse["comments"][number];
 
@@ -148,41 +145,12 @@ const typeStyles = {
 
 function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) {
   const { user } = useAuthStore();
-  const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(comment.content);
   const isOwner = user?.id === comment.author_id;
 
-  const updateComment = useMutation({
-    mutationFn: async (content: string) => {
-      const fetcher = () =>
-        api.comments[":id"].$put({ param: { id: comment.id }, json: { content } });
-      const res = await fetcher();
-      return handleResponse<InferResponseType<(typeof api.comments)[":id"]["$put"], 200>>(
-        res,
-        fetcher,
-      );
-    },
-    onSuccess: () => {
-      setIsEditing(false);
-      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId, "comments"] });
-    },
-  });
-
-  const deleteComment = useMutation({
-    mutationFn: async () => {
-      const fetcher = () => api.comments[":id"].$delete({ param: { id: comment.id } });
-      const res = await fetcher();
-      return handleResponse<InferResponseType<(typeof api.comments)[":id"]["$delete"], 200>>(
-        res,
-        fetcher,
-      );
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId, "comments"] });
-      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId] });
-    },
-  });
+  const updateComment = useUpdateComment(nodeId);
+  const deleteComment = useDeleteComment(nodeId);
 
   return (
     <div className="flex gap-3">
@@ -213,7 +181,7 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
               <button
                 onClick={() => {
                   if (window.confirm("このコメントを削除しますか？")) {
-                    deleteComment.mutate();
+                    deleteComment.mutate(comment.id);
                   }
                 }}
                 disabled={deleteComment.isPending}
@@ -234,13 +202,21 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
               autoFocus
               onKeyDown={(e) => {
                 if (e.key === "Enter" && editContent.trim()) {
-                  updateComment.mutate(editContent.trim());
+                  updateComment.mutate(
+                    { commentId: comment.id, content: editContent.trim() },
+                    { onSuccess: () => setIsEditing(false) },
+                  );
                 }
                 if (e.key === "Escape") setIsEditing(false);
               }}
             />
             <button
-              onClick={() => updateComment.mutate(editContent.trim())}
+              onClick={() =>
+                updateComment.mutate(
+                  { commentId: comment.id, content: editContent.trim() },
+                  { onSuccess: () => setIsEditing(false) },
+                )
+              }
               disabled={updateComment.isPending || !editContent.trim()}
               className="rounded p-1 text-primary hover:bg-primary/10"
             >
@@ -306,19 +282,7 @@ function NodeDetailContent({ id }: { id: string }) {
     },
   });
 
-  const postComment = useMutation({
-    mutationFn: async (content: string) => {
-      const fetcher = () =>
-        api.nodes[":nodeId"].comments.$post({ param: { nodeId: id }, json: { content } });
-      const res = await fetcher();
-      return handleResponse<CommentCreateResponse>(res, fetcher);
-    },
-    onSuccess: () => {
-      setCommentText("");
-      void queryClient.invalidateQueries({ queryKey: ["nodes", id, "comments"] });
-      void queryClient.invalidateQueries({ queryKey: ["nodes", id] });
-    },
-  });
+  const postComment = usePostComment(id);
 
   const updateNode = useMutation({
     mutationFn: async (body: { title?: string; content?: string; tags?: string[] }) => {
@@ -563,7 +527,9 @@ function NodeDetailContent({ id }: { id: string }) {
           onSubmit={(e) => {
             e.preventDefault();
             if (commentText.trim()) {
-              postComment.mutate(commentText.trim());
+              postComment.mutate(commentText.trim(), {
+                onSuccess: () => setCommentText(""),
+              });
             }
           }}
         >

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "clsx": "^2.1.1",
         "hono": "4.11.7",
         "lucide-react": "^0.544.0",
+        "motion": "^12.34.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.0.2",
@@ -749,6 +750,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "framer-motion": ["framer-motion@12.34.0", "", { "dependencies": { "motion-dom": "^12.34.0", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
@@ -828,6 +831,12 @@
     "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
 
     "miniflare": ["miniflare@4.20260205.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260205.0", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-jG1TknEDeFqcq/z5gsOm1rKeg4cNG7ruWxEuiPxl3pnQumavxo8kFpeQC6XKVpAhh2PI9ODGyIYlgd77sTHl5g=="],
+
+    "motion": ["motion@12.34.0", "", { "dependencies": { "framer-motion": "^12.34.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA=="],
+
+    "motion-dom": ["motion-dom@12.34.0", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q=="],
+
+    "motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 


### PR DESCRIPTION
## Summary

- **Optimistic updates**: Extract reaction/comment mutations into dedicated hooks with instant UI feedback via cache manipulation and rollback on error
- **Login page redesign**: Yaruo AA character with motion animations, blurred background orbs, smooth login-to-home transition
- **Header cleanup**: Remove login button from unauthenticated state, hide header on `/login`, brand title to foreground color

## Changes

### Optimistic updates
- `hooks/use-toggle-reaction.ts`: Walks all `["nodes"]` query caches to flip `is_reacted`/`count` instantly, rollback on error
- `hooks/use-comments.ts`: `usePostComment` / `useUpdateComment` / `useDeleteComment` with temp comment insertion, tree traversal for nested replies
- `ReactionButtons.tsx`: Uses hook, removes `disabled={isPending}` for rapid toggling
- `detail.tsx`: Inline mutations replaced with hook calls

### Login page
- Yaruo AA (arms crossed) with speech bubble, floating animation via `motion`
- Animated grey background orbs (`blur-[100px]`)
- Login success transition: brightness flash → blur → scale → navigate
- `GoogleLoginButton`: Navigation moved to `LoginPage` for transition control

## Test plan
- [ ] Toggle reactions on list and detail — UI updates instantly, reconciles on settle
- [ ] Post/edit/delete comments — appears/updates/disappears immediately
- [ ] Reaction error (e.g. network off) — rolls back to previous state
- [ ] Login page renders AA + orbs + Google button
- [ ] Login success plays transition animation before navigating to home
- [ ] Header hidden on `/login`, visible on all other pages
- [ ] Dark mode: text readable, orbs subtle

🤖 Generated with [Claude Code](https://claude.com/claude-code)