### PR TITLE
fix(web): improve responsive layout for login and detail pages

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -74,7 +74,7 @@ function LoginPage() {
       </AnimatePresence>
 
       <motion.div
-        className="w-full max-w-lg px-6"
+        className="w-full max-w-sm px-6 md:max-w-lg"
         animate={
           isTransitioning
             ? {
@@ -94,7 +94,7 @@ function LoginPage() {
         }}
       >
         {/* Brand + Yaruo */}
-        <div className="flex items-end justify-center gap-6">
+        <div className="flex items-end justify-between">
           {/* Brand */}
           <motion.div
             className="shrink-0 select-none"
@@ -102,7 +102,7 @@ function LoginPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, delay: 0.2 }}
           >
-            <h1 className="text-5xl font-bold tracking-tight text-foreground">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground md:text-5xl">
               Inspire
               <br />
               Hub
@@ -111,7 +111,7 @@ function LoginPage() {
 
           {/* Yaruo */}
           <motion.pre
-            className="shrink-0 select-none text-[11px] leading-[1.2] text-foreground/80"
+            className="shrink-0 select-none text-[9px] leading-[1.2] text-foreground/80 md:text-[11px]"
             style={{
               fontFamily: "'Mona','IPAMonaPGothic','MS PGothic',monospace",
             }}

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -415,7 +415,7 @@ function NodeDetailContent({ id }: { id: string }) {
             <ReactionButtons nodeId={node.id} reactions={node.reactions} variant="detail" />
           </div>
 
-          <div className="mt-4 flex gap-2">
+          <div className="mt-4 flex flex-wrap gap-2">
             <DeriveIdeaDialog
               parentNodeId={node.id}
               parentTitle={node.title}


### PR DESCRIPTION
## Summary
- ログイン画面: ブランド左・やる夫AA右の `justify-between` レイアウトに変更、モバイルでフォントサイズ・AA縮小、コンテナ幅を `max-w-sm` に
- 詳細画面: アクションボタン（派生/編集/削除）に `flex-wrap` 追加で狭画面での溢れ防止

## Test plan
- [ ] DevTools モバイルビューポート (375px) でログイン画面確認 — ブランドとAAが崩れず表示
- [ ] デスクトップ幅でログイン画面確認 — 従来通りのレイアウト
- [ ] 詳細画面でアクションボタンが狭画面で折り返し表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)