### PR TITLE
feat: いいね済みノードフィルタ & リロード時のリアクション状態修正

### DIFF
--- a/apps/api/src/routes/nodes.test.ts
+++ b/apps/api/src/routes/nodes.test.ts
@@ -148,6 +148,40 @@ describe("Node Routes", () => {
     expect(res.status).toBe(400);
   });
 
+  test("GET /nodes?liked_by=me without auth should return 401", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const res = await app.request("/nodes?liked_by=me", { method: "GET" }, mockEnv);
+
+    expect(res.status).toBe(401);
+  });
+
+  test("GET /nodes?liked_by=me with auth should return 200", async () => {
+    const app = new Hono();
+    app.route("/nodes", nodeRoutes);
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await sign(
+      { sub: "test-user-id", email: "test@example.com", type: "access", iat: now, exp: now + 900 },
+      mockEnv.JWT_ACCESS_SECRET,
+      "HS256",
+    );
+
+    const res = await app.request(
+      "/nodes?liked_by=me",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { nodes: unknown[] };
+    expect(Array.isArray(data.nodes)).toBe(true);
+  });
+
   test("GET /nodes/:id should return 404 for non-existent node", async () => {
     const app = new Hono();
     app.route("/nodes", nodeRoutes);

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -55,6 +55,12 @@ const nodes = new Hono<HonoEnv>()
           schema: { type: "string", enum: ["recent", "popular"] },
         },
         {
+          name: "liked_by",
+          in: "query",
+          required: false,
+          schema: { type: "string", enum: ["me"] },
+        },
+        {
           name: "limit",
           in: "query",
           required: false,
@@ -71,12 +77,32 @@ const nodes = new Hono<HonoEnv>()
             },
           },
         },
+        401: {
+          description: "認証エラー（liked_by=me使用時）",
+          content: {
+            "application/json": {
+              schema: resolver(ErrorResponseSchema),
+            },
+          },
+        },
       },
     }),
     optionalAuthMiddleware,
     arktypeQueryValidator(ListNodesQuerySchema),
     async (c) => {
       const query = c.req.valid("query") as ListNodesQuery;
+      const userId = c.get("userId");
+
+      if (query.liked_by === "me" && !userId) {
+        return c.json(
+          {
+            success: false as const,
+            error: { code: "UNAUTHORIZED", message: "Authentication required for liked_by=me" },
+          },
+          401,
+        );
+      }
+
       const db = createDb(c.env.DB);
       const nodeService = new NodeService(db);
 
@@ -87,12 +113,10 @@ const nodes = new Hono<HonoEnv>()
         tag: query.tag,
         q: query.q,
         sort: query.sort,
+        liked_by_user_id: query.liked_by === "me" ? userId! : undefined,
         limit: query.limit || 20,
         offset: query.offset || 0,
       });
-
-      // Get user's reaction statuses if authenticated
-      const userId = c.get("userId");
       let likeStatuses: Record<string, boolean> = {};
       let interestedStatuses: Record<string, boolean> = {};
       let wantToTryStatuses: Record<string, boolean> = {};

--- a/apps/api/src/schemas/node.ts
+++ b/apps/api/src/schemas/node.ts
@@ -23,6 +23,7 @@ export const ListNodesQuerySchema = type({
   "tag?": "string",
   "q?": "string",
   "sort?": "'recent' | 'popular'",
+  "liked_by?": "'me'",
   "limit?": type("string.numeric.parse").to("1 <= number <= 100"),
   "offset?": type("string.numeric.parse").to("number >= 0"),
 });

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -113,10 +113,20 @@ export class NodeService {
     tag?: string;
     q?: string;
     sort?: "recent" | "popular";
+    liked_by_user_id?: string;
     limit?: number;
     offset?: number;
   }) {
     let baseQuery = this.db.selectFrom("nodes");
+
+    if (params?.liked_by_user_id) {
+      baseQuery = baseQuery
+        .innerJoin("likes", (join) =>
+          join
+            .onRef("nodes.id", "=", "likes.node_id")
+            .on("likes.user_id", "=", params.liked_by_user_id!),
+        );
+    }
 
     if (params?.parent_node_id) {
       baseQuery = baseQuery
@@ -175,6 +185,8 @@ export class NodeService {
         )`,
         "desc",
       );
+    } else if (params?.liked_by_user_id) {
+      query = query.orderBy(sql`likes.created_at`, "desc");
     } else {
       query = query.orderBy("nodes.created_at", "desc");
     }

--- a/apps/web/src/components/auth/AuthGuard.tsx
+++ b/apps/web/src/components/auth/AuthGuard.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAuthStore } from "@/stores/auth";
+import { refreshToken } from "@/lib/api";
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -9,16 +10,29 @@ interface AuthGuardProps {
 
 export function AuthGuard({ children, fallback }: AuthGuardProps) {
   const navigate = useNavigate();
-  const { isAuthenticated, isLoading } = useAuthStore();
+  const { isAuthenticated, isLoading, accessToken } = useAuthStore();
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (isAuthenticated && !accessToken && !isRefreshing) {
+      setIsRefreshing(true);
+      void refreshToken().then((ok) => {
+        if (!ok) {
+          useAuthStore.getState().logout();
+        }
+        setIsRefreshing(false);
+      });
+    }
+  }, [isAuthenticated, accessToken, isRefreshing]);
+
+  useEffect(() => {
+    if (!isLoading && !isRefreshing && !isAuthenticated) {
       void navigate({ to: "/login" });
     }
-  }, [isAuthenticated, isLoading, navigate]);
+  }, [isAuthenticated, isLoading, isRefreshing, navigate]);
 
-  if (isLoading) {
-    return fallback || <div>Loading...</div>;
+  if (isLoading || isRefreshing) {
+    return fallback || null;
   }
 
   if (!isAuthenticated) {

--- a/apps/web/src/hooks/use-toggle-reaction.ts
+++ b/apps/web/src/hooks/use-toggle-reaction.ts
@@ -97,7 +97,7 @@ export function useToggleReaction(nodeId: string) {
       }
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ["nodes", nodeId] });
+      void queryClient.invalidateQueries({ queryKey: ["nodes"] });
     },
   });
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -26,7 +26,7 @@ export class ApiError extends Error {
 
 let refreshPromise: Promise<boolean> | null = null;
 
-async function refreshToken(): Promise<boolean> {
+export async function refreshToken(): Promise<boolean> {
   if (refreshPromise) return refreshPromise;
   refreshPromise = (async () => {
     try {

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -38,6 +38,19 @@ function ProfilePage() {
     enabled: activeTab === "posts" && !!user,
   });
 
+  const likedPosts = useQuery({
+    queryKey: ["nodes", { liked_by: "me" }],
+    queryFn: async () => {
+      const fetchLiked = () =>
+        api.nodes.$get({
+          query: { liked_by: "me" as const, limit: 50 },
+        });
+      const res = await fetchLiked();
+      return handleResponse<NodesListResponse>(res, fetchLiked);
+    },
+    enabled: activeTab === "liked" && !!user,
+  });
+
   const updateName = useMutation({
     mutationFn: async (name: string) => {
       const fetcher = () => api.users.me.$patch({ json: { name } });
@@ -54,7 +67,7 @@ function ProfilePage() {
 
   if (!user) return null;
 
-  const data = activeTab === "posts" ? myPosts : undefined;
+  const data = activeTab === "posts" ? myPosts : likedPosts;
 
   return (
     <div className="p-4">
@@ -136,18 +149,14 @@ function ProfilePage() {
         )}
 
         {data?.data?.nodes.length === 0 && !data?.isLoading && (
-          <div className="py-12 text-center text-muted-foreground">まだ投稿がありません。</div>
+          <div className="py-12 text-center text-muted-foreground">
+            {activeTab === "posts" ? "まだ投稿がありません。" : "いいねした投稿はありません。"}
+          </div>
         )}
 
         {data?.data?.nodes.map((node) => (
           <NodeCard key={node.id} node={node} />
         ))}
-
-        {activeTab === "liked" && (
-          <div className="py-12 text-center text-muted-foreground">
-            いいねした投稿は近日公開予定です。
-          </div>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- `GET /nodes?liked_by=me` でいいね済みノードのフィルタリングを追加（未認証時は401）
- リロード時に `is_reacted` が `false` にリセットされるバグを修正（AuthGuardでproactive token refresh）
- リアクション操作後の `onSettled` invalidation スコープを全ノードクエリに拡大
- プロフィールの「いいね済み」タブで実データを表示

## Test plan
- [x] `bun run lint` パス
- [x] `bun test` 全20テストパス
- [ ] wrangler再起動後、`GET /nodes?liked_by=me` でいいね済みノードのみ返ることを確認
- [ ] いいね後リロード → `is_reacted: true` が維持されることを確認
- [ ] いいね済みタブでいいね解除 → ノードが一覧から消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)