### PR TITLE
fix(web): 見つけるページの検索プレースホルダーを修正

### DIFF
--- a/apps/web/src/routes/discover.tsx
+++ b/apps/web/src/routes/discover.tsx
@@ -81,7 +81,7 @@ function DiscoverPage() {
             setSearchQuery(e.target.value);
             setSelectedTag(null);
           }}
-          placeholder="ノードやタグで検索..."
+          placeholder="投稿やタグを検索..."
           className="pl-9"
         />
       </div>


### PR DESCRIPTION
## Summary
- 検索ボックスのプレースホルダーを「ノードやタグで検索...」から「投稿やタグを検索...」に変更

## Test plan
- [ ] 見つけるページで検索ボックスのプレースホルダーが「投稿やタグを検索...」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)