### PR TITLE
feat(web): reaction users drawer & node detail redesign

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.6",
     "tw-animate-css": "^1.3.6",
+    "vaul": "^1.1.2",
     "zod": "^4.1.11",
     "zustand": "^5.0.10"
   },

--- a/apps/web/src/components/nodes/NodeCard.tsx
+++ b/apps/web/src/components/nodes/NodeCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { MessageCircle, GitFork } from "lucide-react";
+import { MessageCircle, GitFork, CircleAlert, Lightbulb } from "lucide-react";
 import { ReactionButtons } from "./ReactionButtons";
 
 interface NodeCardProps {
@@ -25,14 +25,17 @@ interface NodeCardProps {
 const typeStyles = {
   issue: {
     label: "課題",
+    icon: CircleAlert,
     className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
   },
   idea: {
     label: "アイデア",
+    icon: Lightbulb,
     className: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
   },
   project: {
     label: "プロジェクト",
+    icon: null as null,
     className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
   },
 };
@@ -66,7 +69,8 @@ export function NodeCard({ node }: NodeCardProps) {
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
-          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${typeStyle.className}`}>
+          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${typeStyle.className}`}>
+            {typeStyle.icon && <typeStyle.icon size={12} />}
             {typeStyle.label}
           </span>
           {node.parent_node && (

--- a/apps/web/src/components/nodes/ReactionButtons.tsx
+++ b/apps/web/src/components/nodes/ReactionButtons.tsx
@@ -1,5 +1,9 @@
+import { useState, useCallback } from "react";
 import { Heart, Flame, Rocket } from "lucide-react";
-import { useToggleReaction, type Reactions } from "@/hooks/use-toggle-reaction";
+import { useToggleReaction, type Reactions, type ReactionType } from "@/hooks/use-toggle-reaction";
+import { useLongPress } from "@/hooks/use-long-press";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { ReactionUsersDrawer } from "./ReactionUsersDrawer";
 
 interface ReactionButtonsProps {
   nodeId: string;
@@ -7,10 +11,10 @@ interface ReactionButtonsProps {
   variant?: "compact" | "detail";
 }
 
-const reactionMeta = [
-  { key: "like", icon: Heart, label: "いいね" },
-  { key: "interested", icon: Flame, label: "気になる" },
-  { key: "want_to_try", icon: Rocket, label: "やってみたい" },
+export const reactionMeta = [
+  { key: "like", icon: Heart, label: "いいね", color: "text-rose-500", bg: "bg-rose-500/15" },
+  { key: "interested", icon: Flame, label: "気になる", color: "text-amber-500", bg: "bg-amber-500/15" },
+  { key: "want_to_try", icon: Rocket, label: "やってみたい", color: "text-violet-500", bg: "bg-violet-500/15" },
 ] as const;
 
 export function ReactionButtons({ nodeId, reactions, variant = "compact" }: ReactionButtonsProps) {
@@ -19,7 +23,7 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
   if (variant === "compact") {
     return (
       <div className="flex items-center gap-1.5">
-        {reactionMeta.map(({ key, icon: Icon }) => {
+        {reactionMeta.map(({ key, icon: Icon, color, bg }) => {
           const reaction = reactions[key];
           const isActive = reaction.is_reacted;
           return (
@@ -32,7 +36,7 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
               }}
               className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs active:scale-90 transition-transform ${
                 isActive
-                  ? "bg-primary/15 text-primary"
+                  ? `${bg} ${color}`
                   : "bg-secondary text-muted-foreground hover:bg-secondary/80"
               }`}
             >
@@ -45,33 +49,98 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
     );
   }
 
+  return <DetailReactionButtons nodeId={nodeId} reactions={reactions} mutation={mutation} />;
+}
+
+function DetailReactionButtons({
+  nodeId,
+  reactions,
+  mutation,
+}: {
+  nodeId: string;
+  reactions: Reactions;
+  mutation: ReturnType<typeof useToggleReaction>;
+}) {
+  const isMobile = useIsMobile();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerType, setDrawerType] = useState<ReactionType>("like");
+
+  const openDrawer = useCallback(
+    (type: ReactionType) => {
+      setDrawerType(type);
+      setDrawerOpen(true);
+    },
+    [],
+  );
+
+  const likeLongPress = useLongPress({ onLongPress: () => openDrawer("like") });
+  const interestedLongPress = useLongPress({ onLongPress: () => openDrawer("interested") });
+  const wantToTryLongPress = useLongPress({ onLongPress: () => openDrawer("want_to_try") });
+
+  const longPressHandlers = {
+    like: likeLongPress,
+    interested: interestedLongPress,
+    want_to_try: wantToTryLongPress,
+  } as const;
+
   return (
-    <div className="flex items-center gap-3">
-      {reactionMeta.map(({ key, icon: Icon, label }) => {
-        const reaction = reactions[key];
-        const isActive = reaction.is_reacted;
-        return (
-          <button
-            key={key}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              mutation.mutate(key);
-            }}
-            className={`flex flex-col items-center active:scale-90 transition-transform ${
-              isActive ? "text-primary" : "text-muted-foreground"
-            }`}
-          >
-            <Icon size={20} className={isActive ? "fill-current" : ""} />
-            <div className="mt-0.5 flex items-center gap-0.5">
-              <span className="text-[10px]">{label}</span>
-              {reaction.count > 0 && (
-                <span className="text-[10px] font-medium">{reaction.count}</span>
-              )}
+    <>
+      <div className="flex items-center gap-3">
+        {reactionMeta.map(({ key, icon: Icon, label, color }) => {
+          const reaction = reactions[key];
+          const isActive = reaction.is_reacted;
+          const lp = longPressHandlers[key];
+          return (
+            <div key={key} className="flex flex-col items-center">
+              <button
+                {...(isMobile
+                  ? {
+                      onTouchStart: lp.onTouchStart,
+                      onTouchMove: lp.onTouchMove,
+                      onTouchEnd: lp.onTouchEnd,
+                    }
+                  : {})}
+                onClick={(e) => {
+                  if (isMobile) {
+                    lp.onClick(e);
+                    if (e.defaultPrevented) return;
+                  }
+                  e.preventDefault();
+                  e.stopPropagation();
+                  mutation.mutate(key);
+                }}
+                className={`flex flex-col items-center active:scale-90 transition-transform ${
+                  isActive ? color : "text-muted-foreground"
+                }`}
+              >
+                <Icon size={20} className={isActive ? "fill-current" : ""} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  openDrawer(key);
+                }}
+                className={`mt-0.5 flex items-center gap-0.5 hover:underline ${
+                  isActive ? color : "text-muted-foreground"
+                }`}
+              >
+                <span className="text-[10px]">{label}</span>
+                {reaction.count > 0 && (
+                  <span className="text-[10px] font-medium">{reaction.count}</span>
+                )}
+              </button>
             </div>
-          </button>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+      <ReactionUsersDrawer
+        nodeId={nodeId}
+        reactions={reactions}
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        initialType={drawerType}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
+++ b/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
@@ -1,0 +1,168 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useReactionUsers } from "@/hooks/use-reaction-users";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import type { Reactions, ReactionType } from "@/hooks/use-toggle-reaction";
+
+import { reactionMeta } from "./ReactionButtons";
+
+interface ReactionUsersDrawerProps {
+  nodeId: string;
+  reactions: Reactions;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialType: ReactionType;
+}
+
+export function ReactionUsersDrawer({
+  nodeId,
+  reactions,
+  open,
+  onOpenChange,
+  initialType,
+}: ReactionUsersDrawerProps) {
+  const isMobile = useIsMobile();
+  const [activeType, setActiveType] = useState<ReactionType>(initialType);
+
+  useEffect(() => {
+    if (open) setActiveType(initialType);
+  }, [open, initialType]);
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useReactionUsers(nodeId, activeType, open);
+
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect();
+      if (!node) return;
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage();
+        }
+      });
+      observerRef.current.observe(node);
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
+
+  const users = data?.pages.flatMap((page) => page.data) ?? [];
+
+  const tabBar = (
+    <div className="flex border-b border-border px-2">
+      {reactionMeta.map(({ key, icon: Icon, label, color }) => {
+        const isActive = activeType === key;
+        return (
+          <button
+            key={key}
+            onClick={() => setActiveType(key)}
+            className={`relative flex flex-1 items-center justify-center gap-1.5 py-3 text-sm ${
+              isActive ? color : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon size={15} className={isActive ? "fill-current" : ""} />
+            <span>{label}</span>
+            <span className="text-xs tabular-nums">{reactions[key].count}</span>
+            {isActive && (
+              <span className={`absolute inset-x-3 bottom-0 h-0.5 rounded-full ${color.replace("text-", "bg-")}`} />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const userList = (
+    <div className="[&_*]:!transition-none">
+      {isLoading ? (
+        <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+          読み込み中...
+        </div>
+      ) : users.length === 0 ? (
+        <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+          まだリアクションはありません
+        </div>
+      ) : (
+        <div className="px-6 py-2">
+          {users.map((user, i) => (
+            <div key={user.user_id}>
+              <div className="flex items-center gap-4 py-3.5">
+                {user.user_picture ? (
+                  <img
+                    src={user.user_picture}
+                    alt=""
+                    className="h-10 w-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-sm font-medium text-muted-foreground">
+                    {(user.user_name ?? "?")[0]}
+                  </div>
+                )}
+                <span className="text-sm font-medium">
+                  {user.user_name ?? "匿名ユーザー"}
+                </span>
+              </div>
+              {i < users.length - 1 && <div className="border-b border-border/50" />}
+            </div>
+          ))}
+          {hasNextPage && <div ref={sentinelRef} className="h-4" />}
+          {isFetchingNextPage && (
+            <div className="py-3 text-center text-xs text-muted-foreground">
+              読み込み中...
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="h-[75vh]">
+          <DrawerHeader>
+            <DrawerTitle>リアクション</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              リアクションしたユーザーの一覧
+            </DrawerDescription>
+          </DrawerHeader>
+          {tabBar}
+          <div className="flex-1 overflow-y-auto">{userList}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
+        <DialogHeader className="px-6 pt-6 pb-4">
+          <DialogTitle>リアクション</DialogTitle>
+          <DialogDescription className="sr-only">
+            リアクションしたユーザーの一覧
+          </DialogDescription>
+        </DialogHeader>
+        {tabBar}
+        <div className="min-h-[60vh] max-h-[70vh] overflow-y-auto">{userList}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -15,10 +15,10 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-background p-6 shadow-lg",
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+const Drawer = DrawerPrimitive.Root;
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPrimitive.Portal>
+      <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 !duration-500" />
+      <DrawerPrimitive.Content
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 flex flex-col rounded-t-xl border-t border-border bg-background !duration-500",
+          className,
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-3 mb-2 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/30" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPrimitive.Portal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("px-4 pb-2", className)} {...props} />;
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/apps/web/src/hooks/use-is-mobile.ts
+++ b/apps/web/src/hooks/use-is-mobile.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/apps/web/src/hooks/use-long-press.ts
+++ b/apps/web/src/hooks/use-long-press.ts
@@ -1,0 +1,42 @@
+import { useCallback, useRef } from "react";
+
+interface UseLongPressOptions {
+  onLongPress: () => void;
+  threshold?: number;
+}
+
+export function useLongPress({ onLongPress, threshold = 500 }: UseLongPressOptions) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const onTouchStart = useCallback(() => {
+    firedRef.current = false;
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      onLongPress();
+    }, threshold);
+  }, [onLongPress, threshold]);
+
+  const onTouchMove = cancel;
+  const onTouchEnd = cancel;
+
+  const onClick = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      if (firedRef.current) {
+        e.preventDefault();
+        e.stopPropagation();
+        firedRef.current = false;
+      }
+    },
+    [],
+  );
+
+  return { onTouchStart, onTouchMove, onTouchEnd, onClick };
+}

--- a/apps/web/src/hooks/use-reaction-users.ts
+++ b/apps/web/src/hooks/use-reaction-users.ts
@@ -1,0 +1,53 @@
+import type { InferResponseType } from "hono/client";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { api, handleResponse } from "@/lib/api";
+import type { ReactionType } from "./use-toggle-reaction";
+
+type ReactionUsersResponse = InferResponseType<
+  (typeof api.nodes)[":id"]["reactions"]["like"]["$get"],
+  200
+>;
+
+function getReactionUsersFetcher(
+  nodeId: string,
+  type: ReactionType,
+  cursor?: string,
+) {
+  const param = { id: nodeId };
+  const query = cursor ? { cursor } : {};
+
+  if (type === "like")
+    return () => api.nodes[":id"].reactions.like.$get({ param, query });
+  if (type === "interested")
+    return () => api.nodes[":id"].reactions.interested.$get({ param, query });
+  return () =>
+    api.nodes[":id"].reactions["want-to-try"].$get({ param, query });
+}
+
+function useReactionUsersQuery(
+  nodeId: string,
+  type: ReactionType,
+  enabled: boolean,
+) {
+  return useInfiniteQuery({
+    queryKey: ["nodes", nodeId, "reaction-users", type],
+    queryFn: async ({ pageParam }) => {
+      const fetcher = getReactionUsersFetcher(nodeId, type, pageParam);
+      const res = await fetcher();
+      return handleResponse<ReactionUsersResponse>(res, fetcher);
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? (lastPage.next_cursor ?? undefined) : undefined,
+    enabled,
+  });
+}
+
+export function useReactionUsers(nodeId: string, activeType: ReactionType, enabled: boolean) {
+  const like = useReactionUsersQuery(nodeId, "like", enabled);
+  const interested = useReactionUsersQuery(nodeId, "interested", enabled);
+  const wantToTry = useReactionUsersQuery(nodeId, "want_to_try", enabled);
+
+  const queries = { like, interested, want_to_try: wantToTry } as const;
+  return queries[activeType];
+}

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { createRoute, Link, useNavigate, type AnyRoute } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { InferResponseType } from "hono/client";
 import {
   ArrowLeft,
-  ChevronRight,
+  CircleAlert,
+  EllipsisVertical,
   GitFork,
-  MessageCircle,
+  Lightbulb,
   Loader2,
   Send,
   Pencil,
@@ -19,10 +20,11 @@ import { useAuthStore } from "@/stores/auth";
 import { usePostComment, useUpdateComment, useDeleteComment } from "@/hooks/use-comments";
 import { ReactionButtons } from "@/components/nodes/ReactionButtons";
 import { TagInput } from "@/components/nodes/TagInput";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -79,67 +81,125 @@ function DeriveIdeaDialog({
     },
   });
 
+  const isMobile = useIsMobile();
+
+  const handleSubmit = () =>
+    createDerived.mutate({ title: title.trim(), content: content.trim(), tags });
+
+  const formFields = (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <label className="text-sm text-muted-foreground">派生元</label>
+        <div className="rounded-lg border border-border bg-secondary/50 p-3">
+          <p className="text-sm font-medium">{parentTitle}</p>
+          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{parentContent}</p>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm text-muted-foreground">タイトル</label>
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="タイトル…"
+          aria-label="タイトル"
+          className="rounded-md bg-background"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm text-muted-foreground">本文</label>
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="内容…"
+          aria-label="内容"
+          rows={4}
+          className="rounded-md bg-background"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm text-muted-foreground">タグ</label>
+        <TagInput tags={tags} onTagsChange={setTags} />
+      </div>
+    </div>
+  );
+
+  const trigger = (
+    <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+      <GitFork size={14} className="mr-1" />
+      派生アイデアを投稿
+    </Button>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {trigger}
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerContent className="h-full bg-gray-50 dark:bg-zinc-900">
+            <div className="flex items-center justify-between px-4 py-4">
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded-lg border border-border bg-background px-4 py-1.5 text-base text-muted-foreground"
+              >
+                キャンセル
+              </button>
+              <span className="text-base font-semibold">派生アイデアを投稿</span>
+              <button
+                onClick={handleSubmit}
+                disabled={createDerived.isPending || !title.trim()}
+                className="rounded-lg bg-primary px-4 py-1.5 text-base font-semibold text-primary-foreground disabled:opacity-50"
+              >
+                {createDerived.isPending ? "投稿中…" : "投稿"}
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 pb-6">{formFields}</div>
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          <GitFork size={14} className="mr-1" />
-          アイデアを派生
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>派生アイデアを投稿</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          <div className="rounded-lg border border-border bg-secondary/50 p-3">
-            <p className="text-sm font-medium">{parentTitle}</p>
-            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{parentContent}</p>
-          </div>
-          <Input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="タイトル…"
-            aria-label="タイトル"
-            className="bg-background"
-          />
-          <Textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="内容…"
-            aria-label="内容"
-            rows={4}
-            className="bg-background"
-          />
-          <TagInput tags={tags} onTagsChange={setTags} />
+    <>
+      {trigger}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>派生アイデアを投稿</DialogTitle>
+          </DialogHeader>
+          <div className="mt-2">{formFields}</div>
           <Button
-            onClick={() =>
-              createDerived.mutate({ title: title.trim(), content: content.trim(), tags })
-            }
+            className="mt-2 w-full"
+            onClick={handleSubmit}
             disabled={createDerived.isPending || !title.trim()}
-            className="w-full"
           >
             {createDerived.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             投稿
           </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
 const typeStyles = {
   issue: {
     label: "課題",
+    icon: CircleAlert,
     className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+    textClassName: "text-red-800 dark:text-red-300",
   },
   idea: {
     label: "アイデア",
+    icon: Lightbulb,
     className: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+    textClassName: "text-blue-800 dark:text-blue-300",
   },
   project: {
     label: "プロジェクト",
+    icon: null,
     className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+    textClassName: "text-green-800 dark:text-green-300",
   },
 };
 
@@ -253,6 +313,19 @@ function NodeDetailContent({ id }: { id: string }) {
   const [editTitle, setEditTitle] = useState("");
   const [editContent, setEditContent] = useState("");
   const [editTags, setEditTags] = useState<string[]>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [menuOpen]);
 
   const nodeQuery = useQuery({
     queryKey: ["nodes", id],
@@ -333,13 +406,53 @@ function NodeDetailContent({ id }: { id: string }) {
 
   return (
     <div className="p-4">
-      <Link
-        to="/"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft size={16} />
-        戻る
-      </Link>
+      <div className="mb-4 flex items-center justify-between">
+        <Link
+          to="/"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-secondary hover:text-foreground"
+          aria-label="戻る"
+        >
+          <ArrowLeft size={18} />
+        </Link>
+        {isOwner && !isEditing && (
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={() => setMenuOpen((prev) => !prev)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-secondary hover:text-foreground"
+              aria-label="メニュー"
+            >
+              <EllipsisVertical size={18} />
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 top-full z-10 mt-1 w-32 overflow-hidden rounded-lg border border-border bg-popover shadow-md">
+                <button
+                  onClick={() => {
+                    setMenuOpen(false);
+                    startEditing();
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-secondary"
+                >
+                  <Pencil size={14} />
+                  編集
+                </button>
+                <button
+                  onClick={() => {
+                    setMenuOpen(false);
+                    if (window.confirm("このノードを削除しますか？")) {
+                      deleteNode.mutate();
+                    }
+                  }}
+                  disabled={deleteNode.isPending}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-secondary"
+                >
+                  <Trash2 size={14} />
+                  削除
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
       {isEditing ? (
         <div className="space-y-3">
@@ -374,27 +487,27 @@ function NodeDetailContent({ id }: { id: string }) {
         <>
           <div className="flex items-center gap-2">
             <span
-              className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${typeStyle.className}`}
+              className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${typeStyle.className}`}
             >
+              {typeStyle.icon && <typeStyle.icon size={12} />}
               {typeStyle.label}
             </span>
             <span className="text-xs text-muted-foreground">
               {new Date(node.created_at).toLocaleDateString()}
             </span>
+            <div className="ml-auto flex items-center gap-1.5">
+              {node.author_picture && (
+                <img
+                  src={node.author_picture}
+                  alt={node.author_name ?? ""}
+                  className="h-5 w-5 rounded-full"
+                />
+              )}
+              <span className="text-xs text-muted-foreground">{node.author_name ?? "匿名"}</span>
+            </div>
           </div>
 
           <h1 className="mt-2 text-2xl font-bold">{node.title}</h1>
-
-          <div className="mt-2 flex items-center gap-2">
-            {node.author_picture && (
-              <img
-                src={node.author_picture}
-                alt={node.author_name ?? ""}
-                className="h-6 w-6 rounded-full"
-              />
-            )}
-            <span className="text-sm text-muted-foreground">{node.author_name ?? "匿名"}</span>
-          </div>
 
           <div className="mt-4 whitespace-pre-wrap text-sm leading-relaxed">{node.content}</div>
 
@@ -411,82 +524,58 @@ function NodeDetailContent({ id }: { id: string }) {
             </div>
           )}
 
-          <div className="mt-4">
+          <div className="mt-6 flex items-center justify-between border-t border-border pt-4">
             <ReactionButtons nodeId={node.id} reactions={node.reactions} variant="detail" />
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2">
             <DeriveIdeaDialog
               parentNodeId={node.id}
               parentTitle={node.title}
               parentContent={node.content}
             />
-            {isOwner && (
-              <>
-                <Button variant="outline" size="sm" onClick={startEditing}>
-                  <Pencil size={14} className="mr-1" />
-                  編集
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    if (window.confirm("このノードを削除しますか？")) {
-                      deleteNode.mutate();
-                    }
-                  }}
-                  disabled={deleteNode.isPending}
-                  className="text-destructive hover:text-destructive"
-                >
-                  <Trash2 size={14} className="mr-1" />
-                  削除
-                </Button>
-              </>
-            )}
           </div>
 
-          {node.parent_node &&
-            (() => {
-              const parentStyle = typeStyles[node.parent_node.type];
-              return (
-                <div className="mt-6 border-t border-border pt-4">
-                  <h2 className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-                    <GitFork size={14} />
-                    派生元
-                  </h2>
-                  <Link
-                    to="/nodes/$id"
-                    params={{ id: node.parent_node.id }}
-                    className="group mt-2 flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
-                  >
-                    <span
-                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${parentStyle.className}`}
-                    >
-                      {parentStyle.label}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                      {node.parent_node.title}
-                    </span>
-                    <ChevronRight
-                      size={16}
-                      className="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-primary"
-                    />
-                  </Link>
-                </div>
-              );
-            })()}
         </>
       )}
 
-      {childNodesQuery.data && childNodesQuery.data.nodes.length > 0 && (
+      {(node.parent_node || (childNodesQuery.data && childNodesQuery.data.nodes.length > 0)) && (
         <div className="mt-6 border-t border-border pt-4">
           <h2 className="flex items-center gap-2 font-semibold">
             <GitFork size={18} />
-            派生ツリー ({childNodesQuery.data.total})
+            派生ツリー
           </h2>
           <div className="relative mt-3 ml-3">
             <span className="absolute left-0 top-0 bottom-0 w-px bg-border" />
-            {childNodesQuery.data.nodes.map((child) => {
+
+            {node.parent_node &&
+              (() => {
+                const parentStyle = typeStyles[node.parent_node.type];
+                return (
+                  <div className="relative pl-5 pb-2">
+                    <span className="absolute left-0 top-4 h-px w-4 bg-border" />
+                    <Link
+                      to="/nodes/$id"
+                      params={{ id: node.parent_node.id }}
+                      className="group flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
+                    >
+                      {parentStyle.icon && (
+                        <parentStyle.icon size={20} className={`shrink-0 ${parentStyle.textClassName}`} />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                            派生元
+                          </span>
+                          <span className={`text-xs ${parentStyle.textClassName}`}>
+                            {parentStyle.label}
+                          </span>
+                        </div>
+                        <p className="mt-1 truncate text-sm font-medium">{node.parent_node.title}</p>
+                      </div>
+                    </Link>
+                  </div>
+                );
+              })()}
+
+            {childNodesQuery.data?.nodes.map((child) => {
               const style = typeStyles[child.type];
               return (
                 <div key={child.id} className="relative pl-5 pb-2 last:pb-0">
@@ -496,18 +585,21 @@ function NodeDetailContent({ id }: { id: string }) {
                     params={{ id: child.id }}
                     className="group flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
                   >
-                    <span
-                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${style.className}`}
-                    >
-                      {style.label}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                      {child.title}
-                    </span>
-                    <ChevronRight
-                      size={16}
-                      className="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-primary"
-                    />
+                    {style.icon && (
+                      <style.icon size={20} className={`shrink-0 ${style.textClassName}`} />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                          派生先
+                        </span>
+                        <span className={`text-xs ${style.textClassName}`}>
+                          {style.label}
+                        </span>
+                      </div>
+                      <p className="mt-1 truncate text-sm font-medium">{child.title}</p>
+                      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{child.content}</p>
+                    </div>
                   </Link>
                 </div>
               );
@@ -517,9 +609,8 @@ function NodeDetailContent({ id }: { id: string }) {
       )}
 
       <div className="mt-6 border-t border-border pt-4">
-        <h2 className="flex items-center gap-2 font-semibold">
-          <MessageCircle size={18} />
-          コメント ({commentsQuery.data?.total ?? 0})
+        <h2 className="font-semibold">
+          コメント {commentsQuery.data?.total ?? 0}
         </h2>
 
         <form
@@ -537,7 +628,7 @@ function NodeDetailContent({ id }: { id: string }) {
             type="text"
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
-            placeholder="コメント..."
+            placeholder="コメントを入力"
             className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm"
           />
           <Button type="submit" size="sm" disabled={postComment.isPending || !commentText.trim()}>

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.6",
         "tw-animate-css": "^1.3.6",
+        "vaul": "^1.1.2",
         "zod": "^4.1.11",
         "zustand": "^5.0.10",
       },
@@ -989,6 +990,8 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 


### PR DESCRIPTION
## Summary
- **Drawer/hooks基盤**: vaul Drawerコンポーネント、useIsMobile、useLongPressフック追加
- **リアクションユーザー表示**: 詳細ページでリアクションボタン長押し → 誰がリアクションしたかDrawerで表示（カーソルページネーション対応）
- **ノード詳細ページデザイン改善**:
  - 編集/削除を3点メニュー(⋮)に集約
  - タイプバッジにアイコン追加（💡アイデア、❗課題）
  - 著者情報をバッジ行の右端に配置
  - 派生アイデア投稿フォームをモバイルでDrawer表示
  - 派生元・派生先を統一ツリービューに統合
  - コメント欄・リアクション周りのスペーシング調整

## Test plan
- [ ] 自分の投稿で右上⋮メニュー → 編集/削除が動作すること
- [ ] 他人の投稿で⋮メニューが非表示であること
- [ ] リアクションボタン長押しでユーザー一覧Drawerが表示されること
- [ ] 派生アイデア投稿がモバイルでDrawer、デスクトップでDialogとして動作すること
- [ ] 派生ツリーに派生元・派生先が正しく表示されること
- [ ] 一覧画面のバッジにもアイコンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)