### PR TITLE
fix(web): polish node detail page UX

### DIFF
--- a/apps/web/src/components/BottomNav.tsx
+++ b/apps/web/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { Link, useMatchRoute } from "@tanstack/react-router";
+import { Link, useMatchRoute, useLocation } from "@tanstack/react-router";
 import { Home, Compass, Plus, User } from "lucide-react";
 
 const navItems = [
@@ -9,6 +9,8 @@ const navItems = [
 
 export function BottomNav() {
   const matchRoute = useMatchRoute();
+  const location = useLocation();
+  const isDetailPage = /^\/nodes\/[^/]+$/.test(location.pathname) && !location.pathname.endsWith("/new");
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur-sm md:hidden">
@@ -29,12 +31,14 @@ export function BottomNav() {
           );
         })}
       </div>
-      <Link
-        to="/nodes/new"
-        className="absolute -top-16 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform"
-      >
-        <Plus size={24} />
-      </Link>
+      {!isDetailPage && (
+        <Link
+          to="/nodes/new"
+          className="absolute -top-16 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform"
+        >
+          <Plus size={24} />
+        </Link>
+      )}
     </nav>
   );
 }

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -537,7 +537,7 @@ function NodeDetailContent({ id }: { id: string }) {
       )}
 
       {(node.parent_node || (childNodesQuery.data && childNodesQuery.data.nodes.length > 0)) && (
-        <div className="mt-6 border-t border-border pt-4">
+        <div className="mt-6">
           <h2 className="flex items-center gap-2 font-semibold">
             <GitFork size={18} />
             派生ツリー
@@ -608,13 +608,13 @@ function NodeDetailContent({ id }: { id: string }) {
         </div>
       )}
 
-      <div className="mt-6 border-t border-border pt-4">
+      <div className="mt-6">
         <h2 className="font-semibold">
           コメント {commentsQuery.data?.total ?? 0}
         </h2>
 
         <form
-          className="mt-3 flex gap-2"
+          className="mt-3"
           onSubmit={(e) => {
             e.preventDefault();
             if (commentText.trim()) {
@@ -624,16 +624,18 @@ function NodeDetailContent({ id }: { id: string }) {
             }
           }}
         >
-          <input
-            type="text"
-            value={commentText}
-            onChange={(e) => setCommentText(e.target.value)}
-            placeholder="コメントを入力"
-            className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm"
-          />
-          <Button type="submit" size="sm" disabled={postComment.isPending || !commentText.trim()}>
-            <Send size={14} />
-          </Button>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              placeholder="コメントを入力"
+              className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm"
+            />
+            <Button type="submit" size="sm" disabled={postComment.isPending || !commentText.trim()}>
+              <Send size={14} />
+            </Button>
+          </div>
         </form>
 
         <div className="mt-4 space-y-4">


### PR DESCRIPTION
## Summary
- 詳細ページでモバイルのFAB(+)ボタンを非表示（コメント欄との重なり解消）
- コメント送信ボタンをinputと垂直中央揃え
- 派生ツリー・コメントセクションの不要な区切り線を削除

## Test plan
- [ ] 詳細ページでプラスボタンが非表示、他ページでは表示されること
- [ ] コメント送信ボタンがinputと同じ高さに揃っていること
- [ ] 派生ツリー・コメント周りのレイアウトが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)