### PR TITLE
refactor(web): NodeCardの型をhono RPC推論に移行

### DIFF
--- a/apps/web/src/components/nodes/NodeCard.tsx
+++ b/apps/web/src/components/nodes/NodeCard.tsx
@@ -1,25 +1,14 @@
 import { Link } from "@tanstack/react-router";
 import { MessageCircle, GitFork, CircleAlert, Lightbulb } from "lucide-react";
+import type { InferResponseType } from "hono/client";
+import { api } from "@/lib/api";
 import { ReactionButtons } from "./ReactionButtons";
 
+type NodesResponse = InferResponseType<(typeof api.nodes)["$get"], 200>;
+type Node = NodesResponse["nodes"][number];
+
 interface NodeCardProps {
-  node: {
-    id: string;
-    type: "issue" | "idea" | "project";
-    title: string;
-    content: string;
-    author_name: string | null;
-    author_picture: string | null;
-    created_at: string;
-    tags: { id: string; name: string }[];
-    reactions: {
-      like: { count: number; is_reacted?: boolean };
-      interested: { count: number; is_reacted?: boolean };
-      want_to_try: { count: number; is_reacted?: boolean };
-    };
-    comment_count: number;
-    parent_node?: { id: string; type: string; title: string } | null;
-  };
+  node: Node;
 }
 
 const typeStyles = {

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -187,19 +187,19 @@ const typeStyles = {
     label: "課題",
     icon: CircleAlert,
     className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
-    textClassName: "text-red-800 dark:text-red-300",
+    iconClassName: "text-red-800 dark:text-red-300",
   },
   idea: {
     label: "アイデア",
     icon: Lightbulb,
     className: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-    textClassName: "text-blue-800 dark:text-blue-300",
+    iconClassName: "text-blue-800 dark:text-blue-300",
   },
   project: {
     label: "プロジェクト",
     icon: null,
     className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
-    textClassName: "text-green-800 dark:text-green-300",
+    iconClassName: "text-green-800 dark:text-green-300",
   },
 };
 
@@ -557,17 +557,12 @@ function NodeDetailContent({ id }: { id: string }) {
                       className="group flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
                     >
                       {parentStyle.icon && (
-                        <parentStyle.icon size={20} className={`shrink-0 ${parentStyle.textClassName}`} />
+                        <parentStyle.icon size={20} className={`shrink-0 ${parentStyle.iconClassName}`} />
                       )}
                       <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                            派生元
-                          </span>
-                          <span className={`text-xs ${parentStyle.textClassName}`}>
-                            {parentStyle.label}
-                          </span>
-                        </div>
+                        <span className={`text-xs font-medium ${parentStyle.iconClassName}`}>
+                          派生元{parentStyle.label}
+                        </span>
                         <p className="mt-1 truncate text-sm font-medium">{node.parent_node.title}</p>
                       </div>
                     </Link>
@@ -586,17 +581,12 @@ function NodeDetailContent({ id }: { id: string }) {
                     className="group flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
                   >
                     {style.icon && (
-                      <style.icon size={20} className={`shrink-0 ${style.textClassName}`} />
+                      <style.icon size={20} className={`shrink-0 ${style.iconClassName}`} />
                     )}
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                          派生先
-                        </span>
-                        <span className={`text-xs ${style.textClassName}`}>
-                          {style.label}
-                        </span>
-                      </div>
+                      <span className={`text-xs font-medium ${style.iconClassName}`}>
+                        派生先{style.label}
+                      </span>
                       <p className="mt-1 truncate text-sm font-medium">{child.title}</p>
                       <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{child.content}</p>
                     </div>


### PR DESCRIPTION
## Summary
- `NodeCard` の手書き型定義を `InferResponseType` によるhono RPC型推論に置き換え
- 派生ツリーのラベルをバッジからプレーンな色付きテキスト（派生元アイデア、派生先課題）に変更

## Test plan
- [ ] 一覧画面のNodeCardが正常に表示されること
- [ ] 派生ツリーのラベルが色付きテキストで表示されること
- [ ] `bun run lint` / `bun test` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)