### PR TITLE
fix(web): ノード間遷移時に詳細ページのstateをリセット

### DIFF
--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -653,7 +653,7 @@ function NodeDetailContent({ id }: { id: string }) {
 
 function NodeDetailPage() {
   const { id } = nodeDetailRoute.useParams();
-  return <NodeDetailContent id={id} />;
+  return <NodeDetailContent key={id} id={id} />;
 }
 
 let nodeDetailRoute: ReturnType<typeof createRoute>;


### PR DESCRIPTION
## Summary
- 派生ツリーから別ノードに遷移した際、編集状態・コメント入力・メニュー開閉などが保持されてしまう問題を修正
- `NodeDetailContent` に `key={id}` を追加し、ノードID変更時にReactがコンポーネントを再マウントするようにした

## Test plan
- [ ] 編集モード中に派生ツリーのリンクをクリック → 編集モードが解除されること
- [ ] コメント入力中に派生ツリーのリンクをクリック → 入力内容がリセットされること
- [ ] 3点メニュー開いた状態で遷移 → メニューが閉じていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)