### PR TITLE
docs: add architecture principles to Claude config files

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -36,3 +36,20 @@ paths:
 
 - Avoid N+1 queries: use batch methods with `WHERE IN` + `GROUP BY` for related data
 - Reaction counts, tags, parent nodes should be fetched in batch (see `NodeService.enrichNodes`)
+
+## Architecture
+
+### Layer responsibilities
+- **routes/** — HTTP concerns only: parse request, call service, format response. Never write DB queries directly.
+- **services/** — Business logic + data access. Receive `Kysely<Database>` via constructor. Own all query logic.
+- **schemas/** — Validation and response type definitions. Imported by routes. Must not import routes or services.
+- **lib/** — Shared utilities. Stateless. Must not import routes, services, or schemas.
+- **middleware/** — Cross-cutting HTTP concerns. May import from lib. Must not import from services.
+
+### Dependency rules
+```
+routes → services → lib
+routes → schemas
+routes → middleware → lib
+```
+Any import that violates these arrows is a design error. Extract shared code into the appropriate lower layer.

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -42,3 +42,24 @@ React 19 | TanStack Router + Query | Zustand | Tailwind v4 | Radix UI + CVA | Vi
 ## Path Alias
 
 - `@/` resolves to `src/`
+
+## Architecture
+
+### Layer responsibilities
+- **components/** — Rendering and user interaction. Get behavior via hooks, state via stores. Never call the API directly.
+- **hooks/** — Data fetching/mutation logic (TanStack Query wrappers) + pure functions for cache updates and data transforms.
+- **stores/** — Client-only state (auth, UI preferences). Keep thin. No API calls inside stores.
+- **lib/** — Pure utilities. Must not import React APIs.
+
+### Dependency rules
+```
+components → hooks → lib/api
+components → stores
+hooks → stores (read-only via getState())
+hooks → lib
+```
+Components must not import `lib/api` directly — always go through a hook.
+
+### Pure function extraction pattern
+Logic inside hooks that does not use React APIs (useState, useEffect, useQuery, etc.) should be named-exported from the same file.
+This enables unit testing without rendering (e.g. `updateReactionsInData`, `removeCommentById`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,13 @@ Monorepo: `apps/api` (Hono on Cloudflare Workers + D1/SQLite via Kysely).
 - When implementing endpoints or features, ask about naming and placement BEFORE implementing. Do not assume.
 - Keep changes minimal and scoped.
 
+## Architecture principles
+
+- **Dependency direction**: Dependencies flow inward. routes→services→lib, components→hooks→lib. A reverse dependency is a design error.
+- **No circular imports**: If A imports B, B must not import A (directly or transitively). Extract shared types/functions into a third module.
+- **Separate pure logic**: Business logic that does not require I/O (HTTP, DB, DOM) should be extracted as pure functions, testable without infrastructure mocks.
+- **Constructor injection at I/O boundaries**: Classes that perform I/O receive dependencies via constructor. Inject rather than import globals to ensure testability.
+
 ## Runtime
 
 Use Bun, not Node.js. `bun test`, `bun run <script>`, `bunx <pkg>`.


### PR DESCRIPTION
## Summary
- Add `## Architecture principles` section to `CLAUDE.md` (dependency direction, no circular imports, pure logic separation, constructor injection)
- Add `## Architecture` section to `.claude/rules/api.md` (layer responsibilities and dependency rules for routes/services/schemas/lib/middleware)
- Add `## Architecture` section to `.claude/rules/web.md` (layer responsibilities, dependency rules, and pure function extraction pattern for components/hooks/stores/lib)

## Test plan
- [x] `bun run lint` passes (config-only changes, no code impact)
- [x] `bun test` — no new failures (pre-existing web test env issues only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)