### PR TITLE
refactor(web): extract hooks to fix component→lib/api violations

### DIFF
--- a/apps/web/src/components/auth/AuthGuard.tsx
+++ b/apps/web/src/components/auth/AuthGuard.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAuthStore } from "@/stores/auth";
-import { refreshToken } from "@/lib/api";
+import { useTokenRefresh } from "@/hooks/use-token-refresh";
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -10,20 +10,8 @@ interface AuthGuardProps {
 
 export function AuthGuard({ children, fallback }: AuthGuardProps) {
   const navigate = useNavigate();
-  const { isAuthenticated, isLoading, accessToken } = useAuthStore();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  useEffect(() => {
-    if (isAuthenticated && !accessToken && !isRefreshing) {
-      setIsRefreshing(true);
-      void refreshToken().then((ok) => {
-        if (!ok) {
-          useAuthStore.getState().logout();
-        }
-        setIsRefreshing(false);
-      });
-    }
-  }, [isAuthenticated, accessToken, isRefreshing]);
+  const { isAuthenticated, isLoading } = useAuthStore();
+  const { isRefreshing } = useTokenRefresh();
 
   useEffect(() => {
     if (!isLoading && !isRefreshing && !isAuthenticated) {

--- a/apps/web/src/components/nodes/TagInput.tsx
+++ b/apps/web/src/components/nodes/TagInput.tsx
@@ -1,11 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
-import type { InferResponseType } from "hono/client";
 import { Plus, X } from "lucide-react";
-import { api, handleResponse } from "@/lib/api";
 import { useDebounce } from "@/hooks/use-debounce";
-
-type TagsSuggestResponse = InferResponseType<(typeof api.tags)["suggest"]["$get"], 200>;
+import { useTagSuggestions } from "@/hooks/use-tag-suggestions";
 
 interface TagInputProps {
   tags: string[];
@@ -18,14 +14,7 @@ export function TagInput({ tags, onTagsChange }: TagInputProps) {
   const debouncedQuery = useDebounce(tagInput, 300);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const suggestions = useQuery({
-    queryKey: ["tags", "suggest", debouncedQuery],
-    queryFn: async () => {
-      const res = await api.tags.suggest.$get({ query: { q: debouncedQuery, limit: 5 } });
-      return handleResponse<TagsSuggestResponse>(res);
-    },
-    enabled: debouncedQuery.length > 0,
-  });
+  const suggestions = useTagSuggestions(debouncedQuery);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {

--- a/apps/web/src/hooks/use-tag-suggestions.ts
+++ b/apps/web/src/hooks/use-tag-suggestions.ts
@@ -1,0 +1,18 @@
+import type { InferResponseType } from "hono/client";
+import { useQuery } from "@tanstack/react-query";
+import { api, handleResponse } from "@/lib/api";
+
+type TagsSuggestResponse = InferResponseType<(typeof api.tags)["suggest"]["$get"], 200>;
+
+export function useTagSuggestions(query: string) {
+  const { data, isError } = useQuery({
+    queryKey: ["tags", "suggest", query],
+    queryFn: async () => {
+      const res = await api.tags.suggest.$get({ query: { q: query, limit: 5 } });
+      return handleResponse<TagsSuggestResponse>(res);
+    },
+    enabled: query.length > 0,
+  });
+
+  return { data, isError };
+}

--- a/apps/web/src/hooks/use-token-refresh.ts
+++ b/apps/web/src/hooks/use-token-refresh.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { refreshToken } from "@/lib/api";
+import { useAuthStore } from "@/stores/auth";
+
+export function useTokenRefresh() {
+  const { isAuthenticated, accessToken } = useAuthStore();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (isAuthenticated && !accessToken && !isRefreshing) {
+      setIsRefreshing(true);
+      void refreshToken().then((ok) => {
+        if (!ok) {
+          useAuthStore.getState().logout();
+        }
+        setIsRefreshing(false);
+      });
+    }
+  }, [isAuthenticated, accessToken, isRefreshing]);
+
+  return { isRefreshing };
+}


### PR DESCRIPTION
## Summary
- **`useTagSuggestions`** hook extracted from `TagInput.tsx` — moves `useQuery` + tag suggest fetcher into `hooks/use-tag-suggestions.ts`
- **`useTokenRefresh`** hook extracted from `AuthGuard.tsx` — moves refresh token `useEffect` + state into `hooks/use-token-refresh.ts`
- Both components no longer import `lib/api` directly, fixing the architecture rule: `components → hooks → lib/api`

## Test plan
- [x] `bun run lint` passes (0 warnings, 0 errors)
- [x] `bun test` — no new failures (existing failures are pre-existing vitest/bun compat issues)
- [ ] Manual: tag suggestions still appear when typing in TagInput
- [ ] Manual: AuthGuard still refreshes token and redirects unauthenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)