### PR TITLE
fix(web): Lighthouse全項目改善 — a11y・ソースマップ・コード分割・CSP

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://lh3.googleusercontent.com data: blob:; connect-src 'self' https://api.inspirehub.wtnqk.org https://cloudflareinsights.com; frame-src https://accounts.google.com; font-src 'self'

--- a/apps/web/src/components/BottomNav.tsx
+++ b/apps/web/src/components/BottomNav.tsx
@@ -34,6 +34,7 @@ export function BottomNav() {
       {!isDetailPage && (
         <Link
           to="/nodes/new"
+          aria-label="新規ノード作成"
           className="absolute -top-16 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform"
         >
           <Plus size={24} />

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -23,6 +23,7 @@ export function UserMenu() {
   return (
     <button
       onClick={handleLogout}
+      aria-label="ログアウト"
       className="rounded-lg p-2 text-muted-foreground hover:bg-secondary hover:text-foreground"
     >
       <LogOut size={18} />

--- a/apps/web/src/components/nodes/ReactionButtons.tsx
+++ b/apps/web/src/components/nodes/ReactionButtons.tsx
@@ -23,18 +23,19 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
   if (variant === "compact") {
     return (
       <div className="flex items-center gap-1.5">
-        {reactionMeta.map(({ key, icon: Icon, color, bg }) => {
+        {reactionMeta.map(({ key, icon: Icon, label, color, bg }) => {
           const reaction = reactions[key];
           const isActive = reaction.is_reacted;
           return (
             <button
               key={key}
+              aria-label={label}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 mutation.mutate(key);
               }}
-              className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs active:scale-90 transition-transform ${
+              className={`flex items-center gap-1 rounded-full px-2.5 py-1.5 text-xs active:scale-90 transition-transform ${
                 isActive
                   ? `${bg} ${color}`
                   : "bg-secondary text-muted-foreground hover:bg-secondary/80"
@@ -93,6 +94,7 @@ function DetailReactionButtons({
           return (
             <div key={key} className="flex flex-col items-center">
               <button
+                aria-label={label}
                 {...(isMobile
                   ? {
                       onTouchStart: lp.onTouchStart,
@@ -116,6 +118,7 @@ function DetailReactionButtons({
                 <Icon size={20} className={isActive ? "fill-current" : ""} />
               </button>
               <button
+                aria-label={`${label}したユーザーを表示`}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/apps/web/src/hooks/use-token-refresh.ts
+++ b/apps/web/src/hooks/use-token-refresh.ts
@@ -4,7 +4,9 @@ import { useAuthStore } from "@/stores/auth";
 
 export function useTokenRefresh() {
   const { isAuthenticated, accessToken } = useAuthStore();
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(
+    () => isAuthenticated && !accessToken,
+  );
 
   useEffect(() => {
     if (isAuthenticated && !accessToken && !isRefreshing) {
@@ -16,7 +18,7 @@ export function useTokenRefresh() {
         setIsRefreshing(false);
       });
     }
-  }, [isAuthenticated, accessToken, isRefreshing]);
+  }, [isAuthenticated, accessToken]);
 
   return { isRefreshing };
 }

--- a/apps/web/src/routes/nodes/new.tsx
+++ b/apps/web/src/routes/nodes/new.tsx
@@ -13,9 +13,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { TagInput } from "@/components/nodes/TagInput";
 
-type NodeType = "issue" | "idea";
+export type NodeType = "issue" | "idea";
 
-interface SearchParams {
+export interface SearchParams {
   type?: NodeType;
   parent_id?: string;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -36,7 +36,7 @@ code {
   --card-foreground: oklch(0.15 0.01 260);
   --popover: oklch(0.97 0.003 260);
   --popover-foreground: oklch(0.15 0.01 260);
-  --primary: oklch(0.55 0.18 255);
+  --primary: oklch(0.50 0.18 255);
   --primary-foreground: oklch(0.99 0 0);
   --secondary: oklch(0.96 0.005 260);
   --secondary-foreground: oklch(0.25 0.01 260);
@@ -49,7 +49,7 @@ code {
   --border: oklch(0.93 0.005 260);
   --input: oklch(0.93 0.005 260);
   --ring: oklch(0.7 0.1 255);
-  --chart-1: oklch(0.55 0.18 255);
+  --chart-1: oklch(0.50 0.18 255);
   --chart-2: oklch(0.65 0.14 255);
   --chart-3: oklch(0.6 0.15 180);
   --chart-4: oklch(0.75 0.15 80);
@@ -57,12 +57,12 @@ code {
   --radius: 1rem;
   --sidebar: oklch(0.975 0.005 260);
   --sidebar-foreground: oklch(0.15 0.01 260);
-  --sidebar-primary: oklch(0.55 0.18 255);
+  --sidebar-primary: oklch(0.50 0.18 255);
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.96 0.005 260);
   --sidebar-accent-foreground: oklch(0.25 0.01 260);
   --sidebar-border: oklch(0.93 0.005 260);
-  --sidebar-ring: oklch(0.55 0.18 255);
+  --sidebar-ring: oklch(0.50 0.18 255);
 }
 
 .dark {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,9 @@ import { fileURLToPath, URL } from "node:url";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [devtools(), viteReact(), tailwindcss()],
+  build: {
+    sourcemap: "hidden",
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary

Lighthouse計測で指摘された Accessibility / Best Practices / Performance / Security の問題を修正。

- **Accessibility**: aria-label追加、タッチターゲットサイズ拡大、カラーコントラスト改善 (`--primary` L値 0.55→0.50)
- **Best Practices**: `sourcemap: 'hidden'` でソースマップ生成を有効化
- **Performance**: トークンリフレッシュ中のAPI重複呼び出し修正
- **Security**: Cloudflare Pages 用 CSP ヘッダー (`_headers`) を追加

## Changes

| Commit | Category |
|--------|----------|
| `fix(web): アクセシビリティ改善 — aria-label・タッチターゲット・コントラスト` | Accessibility |
| `fix(web): ソースマップ生成を有効化` | Best Practices |
| `fix(web): トークンリフレッシュ中のAPI重複呼び出しを修正` | Performance |
| `feat(web): CSPヘッダーを追加` | Security |

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 53/53 passed
- [ ] Cloudflare Pages にデプロイ後、Lighthouse 再計測で各スコア改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)