### PR TITLE
fix(web): Lighthouse改善 — a11y・ソースマップ・CSP(Report-Only)

### DIFF
--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -11,6 +11,7 @@ The user provides frontend requirements: a component, page, application, or inte
 ## Design Thinking
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:
+
 - **Purpose**: What problem does this interface solve? Who uses it?
 - **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
 - **Constraints**: Technical requirements (framework, performance, accessibility).
@@ -19,6 +20,7 @@ Before coding, understand the context and commit to a BOLD aesthetic direction:
 **CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
 
 Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+
 - Production-grade and functional
 - Visually striking and memorable
 - Cohesive with a clear aesthetic point-of-view
@@ -27,6 +29,7 @@ Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
 ## Frontend Aesthetics Guidelines
 
 Focus on:
+
 - **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
 - **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
 - **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.

--- a/.agents/skills/seo-audit/SKILL.md
+++ b/.agents/skills/seo-audit/SKILL.md
@@ -35,6 +35,7 @@ Before auditing, understand:
 ## Audit Framework
 
 ### Priority Order
+
 1. **Crawlability & Indexation** (can Google find and index it?)
 2. **Technical Foundations** (is the site fast and functional?)
 3. **On-Page Optimization** (is content optimized?)
@@ -48,11 +49,13 @@ Before auditing, understand:
 ### Crawlability
 
 **Robots.txt**
+
 - Check for unintentional blocks
 - Verify important pages allowed
 - Check sitemap reference
 
 **XML Sitemap**
+
 - Exists and accessible
 - Submitted to Search Console
 - Contains only canonical, indexable URLs
@@ -60,12 +63,14 @@ Before auditing, understand:
 - Proper formatting
 
 **Site Architecture**
+
 - Important pages within 3 clicks of homepage
 - Logical hierarchy
 - Internal linking structure
 - No orphan pages
 
 **Crawl Budget Issues** (for large sites)
+
 - Parameterized URLs under control
 - Faceted navigation handled properly
 - Infinite scroll with pagination fallback
@@ -74,11 +79,13 @@ Before auditing, understand:
 ### Indexation
 
 **Index Status**
+
 - site:domain.com check
 - Search Console coverage report
 - Compare indexed vs. expected
 
 **Indexation Issues**
+
 - Noindex tags on important pages
 - Canonicals pointing wrong direction
 - Redirect chains/loops
@@ -86,6 +93,7 @@ Before auditing, understand:
 - Duplicate content without canonicals
 
 **Canonicalization**
+
 - All pages have canonical tags
 - Self-referencing canonicals on unique pages
 - HTTP → HTTPS canonicals
@@ -95,11 +103,13 @@ Before auditing, understand:
 ### Site Speed & Core Web Vitals
 
 **Core Web Vitals**
+
 - LCP (Largest Contentful Paint): < 2.5s
 - INP (Interaction to Next Paint): < 200ms
 - CLS (Cumulative Layout Shift): < 0.1
 
 **Speed Factors**
+
 - Server response time (TTFB)
 - Image optimization
 - JavaScript execution
@@ -109,6 +119,7 @@ Before auditing, understand:
 - Font loading
 
 **Tools**
+
 - PageSpeed Insights
 - WebPageTest
 - Chrome DevTools
@@ -146,6 +157,7 @@ Before auditing, understand:
 ### Title Tags
 
 **Check for:**
+
 - Unique titles for each page
 - Primary keyword near beginning
 - 50-60 characters (visible in SERP)
@@ -153,6 +165,7 @@ Before auditing, understand:
 - Brand name placement (end, usually)
 
 **Common issues:**
+
 - Duplicate titles
 - Too long (truncated)
 - Too short (wasted opportunity)
@@ -162,6 +175,7 @@ Before auditing, understand:
 ### Meta Descriptions
 
 **Check for:**
+
 - Unique descriptions per page
 - 150-160 characters
 - Includes primary keyword
@@ -169,6 +183,7 @@ Before auditing, understand:
 - Call to action
 
 **Common issues:**
+
 - Duplicate descriptions
 - Auto-generated garbage
 - Too long/short
@@ -177,6 +192,7 @@ Before auditing, understand:
 ### Heading Structure
 
 **Check for:**
+
 - One H1 per page
 - H1 contains primary keyword
 - Logical hierarchy (H1 → H2 → H3)
@@ -184,6 +200,7 @@ Before auditing, understand:
 - Not just for styling
 
 **Common issues:**
+
 - Multiple H1s
 - Skip levels (H1 → H3)
 - Headings used for styling only
@@ -192,6 +209,7 @@ Before auditing, understand:
 ### Content Optimization
 
 **Primary Page Content**
+
 - Keyword in first 100 words
 - Related keywords naturally used
 - Sufficient depth/length for topic
@@ -199,6 +217,7 @@ Before auditing, understand:
 - Better than competitors
 
 **Thin Content Issues**
+
 - Pages with little unique content
 - Tag/category pages with no value
 - Doorway pages
@@ -207,6 +226,7 @@ Before auditing, understand:
 ### Image Optimization
 
 **Check for:**
+
 - Descriptive file names
 - Alt text on all images
 - Alt text describes image
@@ -218,6 +238,7 @@ Before auditing, understand:
 ### Internal Linking
 
 **Check for:**
+
 - Important pages well-linked
 - Descriptive anchor text
 - Logical link relationships
@@ -225,6 +246,7 @@ Before auditing, understand:
 - Reasonable link count per page
 
 **Common issues:**
+
 - Orphan pages (no internal links)
 - Over-optimized anchor text
 - Important pages buried
@@ -233,12 +255,14 @@ Before auditing, understand:
 ### Keyword Targeting
 
 **Per Page**
+
 - Clear primary keyword target
 - Title, H1, URL aligned
 - Content satisfies search intent
 - Not competing with other pages (cannibalization)
 
 **Site-Wide**
+
 - Keyword mapping document
 - No major gaps in coverage
 - No keyword cannibalization
@@ -251,21 +275,25 @@ Before auditing, understand:
 ### E-E-A-T Signals
 
 **Experience**
+
 - First-hand experience demonstrated
 - Original insights/data
 - Real examples and case studies
 
 **Expertise**
+
 - Author credentials visible
 - Accurate, detailed information
 - Properly sourced claims
 
 **Authoritativeness**
+
 - Recognized in the space
 - Cited by others
 - Industry credentials
 
 **Trustworthiness**
+
 - Accurate information
 - Transparent about business
 - Contact information available
@@ -291,6 +319,7 @@ Before auditing, understand:
 ## Common Issues by Site Type
 
 ### SaaS/Product Sites
+
 - Product pages lack content depth
 - Blog not integrated with product pages
 - Missing comparison/alternative pages
@@ -298,6 +327,7 @@ Before auditing, understand:
 - No glossary/educational content
 
 ### E-commerce
+
 - Thin category pages
 - Duplicate product descriptions
 - Missing product schema
@@ -305,6 +335,7 @@ Before auditing, understand:
 - Out-of-stock pages mishandled
 
 ### Content/Blog Sites
+
 - Outdated content not refreshed
 - Keyword cannibalization
 - No topical clustering
@@ -312,6 +343,7 @@ Before auditing, understand:
 - Missing author pages
 
 ### Local Business
+
 - Inconsistent NAP
 - Missing local schema
 - No Google Business Profile optimization
@@ -325,12 +357,14 @@ Before auditing, understand:
 ### Audit Report Structure
 
 **Executive Summary**
+
 - Overall health assessment
 - Top 3-5 priority issues
 - Quick wins identified
 
 **Technical SEO Findings**
 For each issue:
+
 - **Issue**: What's wrong
 - **Impact**: SEO impact (High/Medium/Low)
 - **Evidence**: How you found it
@@ -344,6 +378,7 @@ Same format as above
 Same format as above
 
 **Prioritized Action Plan**
+
 1. Critical fixes (blocking indexation/ranking)
 2. High-impact improvements
 3. Quick wins (easy, immediate benefit)
@@ -361,6 +396,7 @@ Same format as above
 ## Tools Referenced
 
 **Free Tools**
+
 - Google Search Console (essential)
 - Google PageSpeed Insights
 - Bing Webmaster Tools
@@ -369,6 +405,7 @@ Same format as above
 - Schema Validator
 
 **Paid Tools** (if available)
+
 - Screaming Frog
 - Ahrefs / Semrush
 - Sitebulb

--- a/.agents/skills/seo-audit/references/aeo-geo-patterns.md
+++ b/.agents/skills/seo-audit/references/aeo-geo-patterns.md
@@ -19,6 +19,7 @@ Use for "What is [X]?" queries.
 ```
 
 **Example:**
+
 ```markdown
 ## What is Answer Engine Optimization?
 
@@ -44,6 +45,7 @@ Use for "How to [X]" queries. Optimal for list snippets.
 ```
 
 **Example:**
+
 ```markdown
 ## How to Optimize Content for Featured Snippets
 
@@ -65,13 +67,13 @@ Use for "[X] vs [Y]" queries. Optimal for table snippets.
 ```markdown
 ## [Option A] vs [Option B]: [Brief Descriptor]
 
-| Feature | [Option A] | [Option B] |
-|---------|------------|------------|
+| Feature      | [Option A]          | [Option B]          |
+| ------------ | ------------------- | ------------------- |
 | [Criteria 1] | [Value/Description] | [Value/Description] |
 | [Criteria 2] | [Value/Description] | [Value/Description] |
 | [Criteria 3] | [Value/Description] | [Value/Description] |
 | [Criteria 4] | [Value/Description] | [Value/Description] |
-| Best For | [Use case] | [Use case] |
+| Best For     | [Use case]          | [Use case]          |
 
 **Bottom line**: [1-2 sentence recommendation based on different needs]
 ```
@@ -121,6 +123,7 @@ Use for topic pages with multiple common questions. Essential for FAQ schema.
 ```
 
 **Tips for FAQ questions:**
+
 - Use natural question phrasing ("How do I..." not "How does one...")
 - Include question words: what, how, why, when, where, who, which
 - Match "People Also Ask" queries from search results
@@ -163,6 +166,7 @@ Statistics increase AI citation rates by 15-30%. Always include sources.
 ```
 
 **Example:**
+
 ```markdown
 Mobile optimization is no longer optional for SEO success. According to Google's 2024 Core Web Vitals report, 70% of web traffic now comes from mobile devices, and pages failing mobile usability standards see 24% higher bounce rates. This makes mobile-first indexing a critical ranking factor.
 ```
@@ -176,6 +180,7 @@ Named expert attribution adds credibility and increases citation likelihood.
 ```
 
 **Example:**
+
 ```markdown
 "The shift from keyword-driven search to intent-driven discovery represents the most significant change in SEO since mobile-first indexing," says Rand Fishkin, Co-founder of SparkToro. This perspective highlights why content strategies must evolve beyond traditional keyword optimization.
 ```
@@ -189,6 +194,7 @@ Structure claims for easy AI extraction with clear attribution.
 ```
 
 **Example:**
+
 ```markdown
 E-E-A-T is the cornerstone of Google's content quality evaluation. Google's Search Quality Rater Guidelines confirm that trust is the most critical factor, stating that "untrustworthy pages have low E-E-A-T no matter how experienced, expert, or authoritative they may seem." This means content creators must prioritize transparency and accuracy above all other optimization tactics.
 ```
@@ -202,6 +208,7 @@ Create quotable, standalone statements that AI can extract directly.
 ```
 
 **Example:**
+
 ```markdown
 **Ideal blog post length for SEO**: The optimal length for SEO blog posts is 1,500-2,500 words for competitive topics. This range allows comprehensive topic coverage while maintaining reader engagement. HubSpot research shows long-form content earns 77% more backlinks than short articles, directly impacting search rankings.
 ```
@@ -214,6 +221,7 @@ Structure claims with evidence for maximum credibility.
 [Opening claim statement].
 
 Evidence supporting this includes:
+
 - [Data point 1 with source]
 - [Data point 2 with source]
 - [Data point 3 with source]
@@ -228,30 +236,35 @@ Evidence supporting this includes:
 Different content domains benefit from different authority signals.
 
 ### Technology Content
+
 - Emphasize technical precision and correct terminology
 - Include version numbers and dates for software/tools
 - Reference official documentation
 - Add code examples where relevant
 
 ### Health/Medical Content
+
 - Cite peer-reviewed studies with publication details
 - Include expert credentials (MD, RN, etc.)
 - Note study limitations and context
 - Add "last reviewed" dates
 
 ### Financial Content
+
 - Reference regulatory bodies (SEC, FTC, etc.)
 - Include specific numbers with timeframes
 - Note that information is educational, not advice
 - Cite recognized financial institutions
 
 ### Legal Content
+
 - Cite specific laws, statutes, and regulations
 - Reference jurisdiction clearly
 - Include professional disclaimers
 - Note when professional consultation is advised
 
 ### Business/Marketing Content
+
 - Include case studies with measurable results
 - Reference industry research and reports
 - Add percentage changes and timeframes
@@ -264,6 +277,7 @@ Different content domains benefit from different authority signals.
 Voice queries are conversational and question-based. Optimize for these patterns:
 
 ### Question Formats for Voice
+
 - "What is..."
 - "How do I..."
 - "Where can I find..."
@@ -272,6 +286,7 @@ Voice queries are conversational and question-based. Optimize for these patterns
 - "Who is..."
 
 ### Voice-Optimized Answer Structure
+
 - Lead with direct answer (under 30 words ideal)
 - Use natural, conversational language
 - Avoid jargon unless targeting expert audience

--- a/.agents/skills/seo-audit/references/ai-writing-detection.md
+++ b/.agents/skills/seo-audit/references/ai-writing-detection.md
@@ -13,20 +13,23 @@ Sources: Grammarly (2025), Microsoft 365 Life Hacks (2025), GPTHuman (2025), Wal
 Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, or parenthetical information. While they have legitimate uses in writing, AI models drastically overuse them.
 
 ### Why Em Dashes Signal AI Writing
+
 - AI models were trained on edited books, academic papers, and style guides where em dashes appear frequently
 - AI uses em dashes as a shortcut for sentence variety instead of commas, colons, or parentheses
 - Most human writers rarely use em dashes because they don't exist as a standard keyboard key
 - The overuse is so consistent that it has become the unofficial signature of ChatGPT writing
 
 ### What To Do Instead
-| Instead of | Use |
-|------------|-----|
-| The results—which were surprising—showed... | The results, which were surprising, showed... |
-| This approach—unlike traditional methods—allows... | This approach, unlike traditional methods, allows... |
-| The study found—as expected—that... | The study found, as expected, that... |
+
+| Instead of                                                 | Use                                                          |
+| ---------------------------------------------------------- | ------------------------------------------------------------ |
+| The results—which were surprising—showed...                | The results, which were surprising, showed...                |
+| This approach—unlike traditional methods—allows...         | This approach, unlike traditional methods, allows...         |
+| The study found—as expected—that...                        | The study found, as expected, that...                        |
 | Communication skills—both written and verbal—are essential | Communication skills (both written and verbal) are essential |
 
 ### Guidelines
+
 - Use commas for most parenthetical information
 - Use colons to introduce explanations or lists
 - Use parentheses for supplementary information
@@ -37,67 +40,68 @@ Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, 
 
 ## Overused Verbs
 
-| Avoid | Use Instead |
-|-------|-------------|
+| Avoid        | Use Instead                            |
+| ------------ | -------------------------------------- |
 | delve (into) | explore, examine, investigate, look at |
-| leverage | use, apply, draw on |
-| optimise | improve, refine, enhance |
-| utilise | use |
-| facilitate | help, enable, support |
-| foster | encourage, support, develop, nurture |
-| bolster | strengthen, support, reinforce |
-| underscore | emphasise, highlight, stress |
-| unveil | reveal, show, introduce, present |
-| navigate | manage, handle, work through |
-| streamline | simplify, make more efficient |
-| enhance | improve, strengthen |
-| endeavour | try, attempt, effort |
-| ascertain | find out, determine, establish |
-| elucidate | explain, clarify, make clear |
+| leverage     | use, apply, draw on                    |
+| optimise     | improve, refine, enhance               |
+| utilise      | use                                    |
+| facilitate   | help, enable, support                  |
+| foster       | encourage, support, develop, nurture   |
+| bolster      | strengthen, support, reinforce         |
+| underscore   | emphasise, highlight, stress           |
+| unveil       | reveal, show, introduce, present       |
+| navigate     | manage, handle, work through           |
+| streamline   | simplify, make more efficient          |
+| enhance      | improve, strengthen                    |
+| endeavour    | try, attempt, effort                   |
+| ascertain    | find out, determine, establish         |
+| elucidate    | explain, clarify, make clear           |
 
 ---
 
 ## Overused Adjectives
 
-| Avoid | Use Instead |
-|-------|-------------|
-| robust | strong, reliable, thorough, solid |
-| comprehensive | complete, thorough, full, detailed |
-| pivotal | key, critical, central, important |
-| crucial | important, key, essential, critical |
-| vital | important, essential, necessary |
-| transformative | significant, important, major |
-| cutting-edge | new, advanced, recent, modern |
-| groundbreaking | new, original, significant |
-| innovative | new, original, creative |
-| seamless | smooth, easy, effortless |
-| intricate | complex, detailed, complicated |
-| nuanced | subtle, complex, detailed |
-| multifaceted | complex, varied, diverse |
-| holistic | complete, whole, comprehensive |
+| Avoid          | Use Instead                         |
+| -------------- | ----------------------------------- |
+| robust         | strong, reliable, thorough, solid   |
+| comprehensive  | complete, thorough, full, detailed  |
+| pivotal        | key, critical, central, important   |
+| crucial        | important, key, essential, critical |
+| vital          | important, essential, necessary     |
+| transformative | significant, important, major       |
+| cutting-edge   | new, advanced, recent, modern       |
+| groundbreaking | new, original, significant          |
+| innovative     | new, original, creative             |
+| seamless       | smooth, easy, effortless            |
+| intricate      | complex, detailed, complicated      |
+| nuanced        | subtle, complex, detailed           |
+| multifaceted   | complex, varied, diverse            |
+| holistic       | complete, whole, comprehensive      |
 
 ---
 
 ## Overused Transitions and Connectors
 
-| Avoid | Use Instead |
-|-------|-------------|
-| furthermore | also, in addition, and |
-| moreover | also, and, besides |
-| notwithstanding | despite, even so, still |
-| that being said | however, but, still |
-| at its core | essentially, fundamentally, basically |
-| to put it simply | in short, simply put |
-| it is worth noting that | note that, importantly |
-| in the realm of | in, within, regarding |
-| in the landscape of | in, within |
-| in today's [anything] | currently, now, today |
+| Avoid                   | Use Instead                           |
+| ----------------------- | ------------------------------------- |
+| furthermore             | also, in addition, and                |
+| moreover                | also, and, besides                    |
+| notwithstanding         | despite, even so, still               |
+| that being said         | however, but, still                   |
+| at its core             | essentially, fundamentally, basically |
+| to put it simply        | in short, simply put                  |
+| it is worth noting that | note that, importantly                |
+| in the realm of         | in, within, regarding                 |
+| in the landscape of     | in, within                            |
+| in today's [anything]   | currently, now, today                 |
 
 ---
 
 ## Phrases That Signal AI Writing
 
 ### Opening Phrases to Avoid
+
 - "In today's fast-paced world..."
 - "In today's digital age..."
 - "In an era of..."
@@ -108,6 +112,7 @@ Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, 
 - "Imagine a world where..."
 
 ### Transitional Phrases to Avoid
+
 - "That being said..."
 - "With that in mind..."
 - "It's worth mentioning that..."
@@ -117,6 +122,7 @@ Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, 
 - "This begs the question..."
 
 ### Concluding Phrases to Avoid
+
 - "In conclusion..."
 - "To sum up..."
 - "By [doing X], you can [achieve Y]..."
@@ -125,6 +131,7 @@ Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, 
 - "At the end of the day..."
 
 ### Structural Patterns to Avoid
+
 - "Whether you're a [X], [Y], or [Z]..." (listing three examples after "whether")
 - "It's not just [X], it's also [Y]..."
 - "Think of [X] as [elaborate metaphor]..."
@@ -163,20 +170,20 @@ These words often add nothing to meaning. Remove them or find specific alternati
 
 ## Academic-Specific AI Tells
 
-| Avoid | Use Instead |
-|-------|-------------|
-| shed light on | clarify, explain, reveal |
-| pave the way for | enable, allow, make possible |
-| a myriad of | many, numerous, various |
-| a plethora of | many, numerous, several |
-| paramount | very important, essential, critical |
-| pertaining to | about, regarding, concerning |
-| prior to | before |
-| subsequent to | after |
-| in light of | because of, given, considering |
-| with respect to | about, regarding, for |
-| in terms of | regarding, for, about |
-| the fact that | that (or rewrite sentence) |
+| Avoid            | Use Instead                         |
+| ---------------- | ----------------------------------- |
+| shed light on    | clarify, explain, reveal            |
+| pave the way for | enable, allow, make possible        |
+| a myriad of      | many, numerous, various             |
+| a plethora of    | many, numerous, several             |
+| paramount        | very important, essential, critical |
+| pertaining to    | about, regarding, concerning        |
+| prior to         | before                              |
+| subsequent to    | after                               |
+| in light of      | because of, given, considering      |
+| with respect to  | about, regarding, for               |
+| in terms of      | regarding, for, about               |
+| the fact that    | that (or rewrite sentence)          |
 
 ---
 

--- a/.agents/skills/vercel-composition-patterns/AGENTS.md
+++ b/.agents/skills/vercel-composition-patterns/AGENTS.md
@@ -73,16 +73,10 @@ function Composer({
       ) : isThread ? (
         <AlsoSendToChannelField id={channelId} />
       ) : null}
-      {isEditing ? (
-        <EditActions />
-      ) : isForwarding ? (
-        <ForwardActions />
-      ) : (
-        <DefaultActions />
-      )}
+      {isEditing ? <EditActions /> : isForwarding ? <ForwardActions /> : <DefaultActions />}
       <Footer onSubmit={onSubmit} />
     </form>
-  )
+  );
 }
 ```
 
@@ -102,7 +96,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Thread composer - adds "also send to channel" field
@@ -118,7 +112,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Edit composer - different footer actions
@@ -133,7 +127,7 @@ function EditComposer() {
         <Composer.SaveEdit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 ```
 
@@ -177,25 +171,21 @@ function Composer({
         </Footer>
       )}
     </form>
-  )
+  );
 }
 ```
 
 **Correct: compound components with shared context**
 
 ```tsx
-const ComposerContext = createContext<ComposerContextValue | null>(null)
+const ComposerContext = createContext<ComposerContextValue | null>(null);
 
 function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
-  return (
-    <ComposerContext value={{ state, actions, meta }}>
-      {children}
-    </ComposerContext>
-  )
+  return <ComposerContext value={{ state, actions, meta }}>{children}</ComposerContext>;
 }
 
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>
+  return <form>{children}</form>;
 }
 
 function ComposerInput() {
@@ -203,21 +193,21 @@ function ComposerInput() {
     state,
     actions: { update },
     meta: { inputRef },
-  } = use(ComposerContext)
+  } = use(ComposerContext);
   return (
     <TextInput
       ref={inputRef}
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  )
+  );
 }
 
 function ComposerSubmit() {
   const {
     actions: { submit },
-  } = use(ComposerContext)
-  return <Button onPress={submit}>Send</Button>
+  } = use(ComposerContext);
+  return <Button onPress={submit}>Send</Button>;
 }
 
 // Export as compound component
@@ -231,7 +221,7 @@ const Composer = {
   Attachments: ComposerAttachments,
   Formatting: ComposerFormatting,
   Emojis: ComposerEmojis,
-}
+};
 ```
 
 **Usage:**
@@ -275,18 +265,15 @@ useState, Zustand, or a server sync.
 ```tsx
 function ChannelComposer({ channelId }: { channelId: string }) {
   // UI component knows about global state implementation
-  const state = useGlobalChannelState(channelId)
-  const { submit, updateInput } = useChannelSync(channelId)
+  const state = useGlobalChannelState(channelId);
+  const { submit, updateInput } = useChannelSync(channelId);
 
   return (
     <Composer.Frame>
-      <Composer.Input
-        value={state.input}
-        onChange={(text) => sync.updateInput(text)}
-      />
+      <Composer.Input value={state.input} onChange={(text) => sync.updateInput(text)} />
       <Composer.Submit onPress={() => sync.submit()} />
     </Composer.Frame>
-  )
+  );
 }
 ```
 
@@ -298,21 +285,17 @@ function ChannelProvider({
   channelId,
   children,
 }: {
-  channelId: string
-  children: React.ReactNode
+  channelId: string;
+  children: React.ReactNode;
 }) {
-  const { state, update, submit } = useGlobalChannel(channelId)
-  const inputRef = useRef(null)
+  const { state, update, submit } = useGlobalChannel(channelId);
+  const inputRef = useRef(null);
 
   return (
-    <Composer.Provider
-      state={state}
-      actions={{ update, submit }}
-      meta={{ inputRef }}
-    >
+    <Composer.Provider state={state} actions={{ update, submit }} meta={{ inputRef }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 // UI component only knows about the context interface
@@ -325,7 +308,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Usage
@@ -334,7 +317,7 @@ function Channel({ channelId }: { channelId: string }) {
     <ChannelProvider channelId={channelId}>
       <ChannelComposer />
     </ChannelProvider>
-  )
+  );
 }
 ```
 
@@ -343,28 +326,25 @@ function Channel({ channelId }: { channelId: string }) {
 ```tsx
 // Local state for ephemeral forms
 function ForwardMessageProvider({ children }) {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
 
   return (
-    <Composer.Provider
-      state={state}
-      actions={{ update: setState, submit: forwardMessage }}
-    >
+    <Composer.Provider state={state} actions={{ update: setState, submit: forwardMessage }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 // Global synced state for channels
 function ChannelProvider({ channelId, children }) {
-  const { state, update, submit } = useGlobalChannel(channelId)
+  const { state, update, submit } = useGlobalChannel(channelId);
 
   return (
     <Composer.Provider state={state} actions={{ update, submit }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 ```
 
@@ -393,8 +373,8 @@ dependency-injectable.
 ```tsx
 function ComposerInput() {
   // Tightly coupled to a specific hook
-  const { input, setInput } = useChannelComposerState()
-  return <TextInput value={input} onChangeText={setInput} />
+  const { input, setInput } = useChannelComposerState();
+  return <TextInput value={input} onChangeText={setInput} />;
 }
 ```
 
@@ -403,27 +383,27 @@ function ComposerInput() {
 ```tsx
 // Define a GENERIC interface that any provider can implement
 interface ComposerState {
-  input: string
-  attachments: Attachment[]
-  isSubmitting: boolean
+  input: string;
+  attachments: Attachment[];
+  isSubmitting: boolean;
 }
 
 interface ComposerActions {
-  update: (updater: (state: ComposerState) => ComposerState) => void
-  submit: () => void
+  update: (updater: (state: ComposerState) => ComposerState) => void;
+  submit: () => void;
 }
 
 interface ComposerMeta {
-  inputRef: React.RefObject<TextInput>
+  inputRef: React.RefObject<TextInput>;
 }
 
 interface ComposerContextValue {
-  state: ComposerState
-  actions: ComposerActions
-  meta: ComposerMeta
+  state: ComposerState;
+  actions: ComposerActions;
+  meta: ComposerMeta;
 }
 
-const ComposerContext = createContext<ComposerContextValue | null>(null)
+const ComposerContext = createContext<ComposerContextValue | null>(null);
 ```
 
 **UI components consume the interface, not the implementation:**
@@ -434,7 +414,7 @@ function ComposerInput() {
     state,
     actions: { update },
     meta,
-  } = use(ComposerContext)
+  } = use(ComposerContext);
 
   // This component works with ANY provider that implements the interface
   return (
@@ -443,7 +423,7 @@ function ComposerInput() {
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  )
+  );
 }
 ```
 
@@ -452,9 +432,9 @@ function ComposerInput() {
 ```tsx
 // Provider A: Local state for ephemeral forms
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState)
-  const inputRef = useRef(null)
-  const submit = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const inputRef = useRef(null);
+  const submit = useForwardMessage();
 
   return (
     <ComposerContext
@@ -466,13 +446,13 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </ComposerContext>
-  )
+  );
 }
 
 // Provider B: Global synced state for channels
 function ChannelProvider({ channelId, children }: Props) {
-  const { state, update, submit } = useGlobalChannel(channelId)
-  const inputRef = useRef(null)
+  const { state, update, submit } = useGlobalChannel(channelId);
+  const inputRef = useRef(null);
 
   return (
     <ComposerContext
@@ -484,7 +464,7 @@ function ChannelProvider({ channelId, children }: Props) {
     >
       {children}
     </ComposerContext>
-  )
+  );
 }
 ```
 
@@ -534,21 +514,21 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  )
+  );
 }
 
 // This button lives OUTSIDE Composer.Frame but can still submit based on its context!
 function ForwardButton() {
   const {
     actions: { submit },
-  } = use(ComposerContext)
-  return <Button onPress={submit}>Forward</Button>
+  } = use(ComposerContext);
+  return <Button onPress={submit}>Forward</Button>;
 }
 
 // This preview lives OUTSIDE Composer.Frame but can read composer's state!
 function MessagePreview() {
-  const { state } = use(ComposerContext)
-  return <Preview message={state.input} attachments={state.attachments} />
+  const { state } = use(ComposerContext);
+  return <Preview message={state.input} attachments={state.attachments} />;
 }
 ```
 
@@ -582,15 +562,15 @@ or awkward refs.
 
 ```tsx
 function ForwardMessageComposer() {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
 
   return (
     <Composer.Frame>
       <Composer.Input />
       <Composer.Footer />
     </Composer.Frame>
-  )
+  );
 }
 
 // Problem: How does this button access composer state?
@@ -604,7 +584,7 @@ function ForwardMessageDialog() {
         <ForwardButton /> {/* Needs to call submit */}
       </DialogActions>
     </Dialog>
-  )
+  );
 }
 ```
 
@@ -612,20 +592,20 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageDialog() {
-  const [input, setInput] = useState('')
+  const [input, setInput] = useState("");
   return (
     <Dialog>
       <ForwardMessageComposer onInputChange={setInput} />
       <MessagePreview input={input} />
     </Dialog>
-  )
+  );
 }
 
 function ForwardMessageComposer({ onInputChange }) {
-  const [state, setState] = useState(initialState)
+  const [state, setState] = useState(initialState);
   useEffect(() => {
-    onInputChange(state.input) // Sync on every change 😬
-  }, [state.input])
+    onInputChange(state.input); // Sync on every change 😬
+  }, [state.input]);
 }
 ```
 
@@ -633,13 +613,13 @@ function ForwardMessageComposer({ onInputChange }) {
 
 ```tsx
 function ForwardMessageDialog() {
-  const stateRef = useRef(null)
+  const stateRef = useRef(null);
   return (
     <Dialog>
       <ForwardMessageComposer stateRef={stateRef} />
       <ForwardButton onPress={() => submit(stateRef.current)} />
     </Dialog>
-  )
+  );
 }
 ```
 
@@ -647,9 +627,9 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
-  const inputRef = useRef(null)
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
+  const inputRef = useRef(null);
 
   return (
     <Composer.Provider
@@ -659,7 +639,7 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 function ForwardMessageDialog() {
@@ -674,12 +654,12 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  )
+  );
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context)
-  return <Button onPress={actions.submit}>Forward</Button>
+  const { actions } = use(Composer.Context);
+  return <Button onPress={actions.submit}>Forward</Button>;
 }
 ```
 
@@ -718,13 +698,7 @@ itself.
 
 ```tsx
 // What does this component actually render?
-<Composer
-  isThread
-  isEditing={false}
-  channelId='abc'
-  showAttachments
-  showFormatting={false}
-/>
+<Composer isThread isEditing={false} channelId="abc" showAttachments showFormatting={false} />
 ```
 
 **Correct: explicit variants**
@@ -760,7 +734,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ThreadProvider>
-  )
+  );
 }
 
 function EditMessageComposer({ messageId }: { messageId: string }) {
@@ -776,7 +750,7 @@ function EditMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </EditMessageProvider>
-  )
+  );
 }
 
 function ForwardMessageComposer({ messageId }: { messageId: string }) {
@@ -791,7 +765,7 @@ function ForwardMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ForwardMessageProvider>
-  )
+  );
 }
 ```
 
@@ -823,9 +797,9 @@ function Composer({
   renderFooter,
   renderActions,
 }: {
-  renderHeader?: () => React.ReactNode
-  renderFooter?: () => React.ReactNode
-  renderActions?: () => React.ReactNode
+  renderHeader?: () => React.ReactNode;
+  renderFooter?: () => React.ReactNode;
+  renderActions?: () => React.ReactNode;
 }) {
   return (
     <form>
@@ -834,7 +808,7 @@ function Composer({
       {renderFooter ? renderFooter() : <DefaultFooter />}
       {renderActions?.()}
     </form>
-  )
+  );
 }
 
 // Usage is awkward and inflexible
@@ -849,18 +823,18 @@ return (
     )}
     renderActions={() => <SubmitButton />}
   />
-)
+);
 ```
 
 **Correct: compound components with children**
 
 ```tsx
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>
+  return <form>{children}</form>;
 }
 
 function ComposerFooter({ children }: { children: React.ReactNode }) {
-  return <footer className='flex'>{children}</footer>
+  return <footer className="flex">{children}</footer>;
 }
 
 // Usage is flexible
@@ -874,17 +848,14 @@ return (
       <SubmitButton />
     </Composer.Footer>
   </Composer.Frame>
-)
+);
 ```
 
 **When render props are appropriate:**
 
 ```tsx
 // Render props work well when you need to pass data back
-<List
-  data={items}
-  renderItem={({ item, index }) => <Item item={item} index={index} />}
-/>
+<List data={items} renderItem={({ item, index }) => <Item item={item} index={index} />} />
 ```
 
 Use render props when the parent needs to provide data or state to the child.
@@ -911,28 +882,28 @@ In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `
 
 ```tsx
 const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
-  return <TextInput ref={ref} {...props} />
-})
+  return <TextInput ref={ref} {...props} />;
+});
 ```
 
 **Correct: ref as a regular prop**
 
 ```tsx
 function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
-  return <TextInput ref={ref} {...props} />
+  return <TextInput ref={ref} {...props} />;
 }
 ```
 
 **Incorrect: useContext in React 19**
 
 ```tsx
-const value = useContext(MyContext)
+const value = useContext(MyContext);
 ```
 
 **Correct: use instead of useContext**
 
 ```tsx
-const value = use(MyContext)
+const value = use(MyContext);
 ```
 
 `use()` can also be called conditionally, unlike `useContext()`.

--- a/.agents/skills/vercel-composition-patterns/SKILL.md
+++ b/.agents/skills/vercel-composition-patterns/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vercel-composition-patterns
-description:
-  React composition patterns that scale. Use when refactoring components with
+description: React composition patterns that scale. Use when refactoring components with
   boolean prop proliferation, building flexible component libraries, or
   designing reusable APIs. Triggers on tasks involving compound components,
   render props, context providers, or component architecture. Includes React 19
@@ -9,7 +8,7 @@ description:
 license: MIT
 metadata:
   author: vercel
-  version: '1.0.0'
+  version: "1.0.0"
 ---
 
 # React Composition Patterns

--- a/.agents/skills/vercel-composition-patterns/rules/architecture-avoid-boolean-props.md
+++ b/.agents/skills/vercel-composition-patterns/rules/architecture-avoid-boolean-props.md
@@ -32,16 +32,10 @@ function Composer({
       ) : isThread ? (
         <AlsoSendToChannelField id={channelId} />
       ) : null}
-      {isEditing ? (
-        <EditActions />
-      ) : isForwarding ? (
-        <ForwardActions />
-      ) : (
-        <DefaultActions />
-      )}
+      {isEditing ? <EditActions /> : isForwarding ? <ForwardActions /> : <DefaultActions />}
       <Footer onSubmit={onSubmit} />
     </form>
-  )
+  );
 }
 ```
 
@@ -61,7 +55,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Thread composer - adds "also send to channel" field
@@ -77,7 +71,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Edit composer - different footer actions
@@ -92,7 +86,7 @@ function EditComposer() {
         <Composer.SaveEdit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 ```
 

--- a/.agents/skills/vercel-composition-patterns/rules/architecture-compound-components.md
+++ b/.agents/skills/vercel-composition-patterns/rules/architecture-compound-components.md
@@ -37,25 +37,21 @@ function Composer({
         </Footer>
       )}
     </form>
-  )
+  );
 }
 ```
 
 **Correct (compound components with shared context):**
 
 ```tsx
-const ComposerContext = createContext<ComposerContextValue | null>(null)
+const ComposerContext = createContext<ComposerContextValue | null>(null);
 
 function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
-  return (
-    <ComposerContext value={{ state, actions, meta }}>
-      {children}
-    </ComposerContext>
-  )
+  return <ComposerContext value={{ state, actions, meta }}>{children}</ComposerContext>;
 }
 
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>
+  return <form>{children}</form>;
 }
 
 function ComposerInput() {
@@ -63,21 +59,21 @@ function ComposerInput() {
     state,
     actions: { update },
     meta: { inputRef },
-  } = use(ComposerContext)
+  } = use(ComposerContext);
   return (
     <TextInput
       ref={inputRef}
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  )
+  );
 }
 
 function ComposerSubmit() {
   const {
     actions: { submit },
-  } = use(ComposerContext)
-  return <Button onPress={submit}>Send</Button>
+  } = use(ComposerContext);
+  return <Button onPress={submit}>Send</Button>;
 }
 
 // Export as compound component
@@ -91,7 +87,7 @@ const Composer = {
   Attachments: ComposerAttachments,
   Formatting: ComposerFormatting,
   Emojis: ComposerEmojis,
-}
+};
 ```
 
 **Usage:**

--- a/.agents/skills/vercel-composition-patterns/rules/patterns-children-over-render-props.md
+++ b/.agents/skills/vercel-composition-patterns/rules/patterns-children-over-render-props.md
@@ -19,9 +19,9 @@ function Composer({
   renderFooter,
   renderActions,
 }: {
-  renderHeader?: () => React.ReactNode
-  renderFooter?: () => React.ReactNode
-  renderActions?: () => React.ReactNode
+  renderHeader?: () => React.ReactNode;
+  renderFooter?: () => React.ReactNode;
+  renderActions?: () => React.ReactNode;
 }) {
   return (
     <form>
@@ -30,7 +30,7 @@ function Composer({
       {renderFooter ? renderFooter() : <DefaultFooter />}
       {renderActions?.()}
     </form>
-  )
+  );
 }
 
 // Usage is awkward and inflexible
@@ -45,18 +45,18 @@ return (
     )}
     renderActions={() => <SubmitButton />}
   />
-)
+);
 ```
 
 **Correct (compound components with children):**
 
 ```tsx
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>
+  return <form>{children}</form>;
 }
 
 function ComposerFooter({ children }: { children: React.ReactNode }) {
-  return <footer className='flex'>{children}</footer>
+  return <footer className="flex">{children}</footer>;
 }
 
 // Usage is flexible
@@ -70,17 +70,14 @@ return (
       <SubmitButton />
     </Composer.Footer>
   </Composer.Frame>
-)
+);
 ```
 
 **When render props are appropriate:**
 
 ```tsx
 // Render props work well when you need to pass data back
-<List
-  data={items}
-  renderItem={({ item, index }) => <Item item={item} index={index} />}
-/>
+<List data={items} renderItem={({ item, index }) => <Item item={item} index={index} />} />
 ```
 
 Use render props when the parent needs to provide data or state to the child.

--- a/.agents/skills/vercel-composition-patterns/rules/patterns-explicit-variants.md
+++ b/.agents/skills/vercel-composition-patterns/rules/patterns-explicit-variants.md
@@ -15,13 +15,7 @@ itself.
 
 ```tsx
 // What does this component actually render?
-<Composer
-  isThread
-  isEditing={false}
-  channelId='abc'
-  showAttachments
-  showFormatting={false}
-/>
+<Composer isThread isEditing={false} channelId="abc" showAttachments showFormatting={false} />
 ```
 
 **Correct (explicit variants):**
@@ -56,7 +50,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ThreadProvider>
-  )
+  );
 }
 
 function EditMessageComposer({ messageId }: { messageId: string }) {
@@ -72,7 +66,7 @@ function EditMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </EditMessageProvider>
-  )
+  );
 }
 
 function ForwardMessageComposer({ messageId }: { messageId: string }) {
@@ -87,7 +81,7 @@ function ForwardMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ForwardMessageProvider>
-  )
+  );
 }
 ```
 

--- a/.agents/skills/vercel-composition-patterns/rules/react19-no-forwardref.md
+++ b/.agents/skills/vercel-composition-patterns/rules/react19-no-forwardref.md
@@ -15,28 +15,28 @@ In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `
 
 ```tsx
 const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
-  return <TextInput ref={ref} {...props} />
-})
+  return <TextInput ref={ref} {...props} />;
+});
 ```
 
 **Correct (ref as a regular prop):**
 
 ```tsx
 function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
-  return <TextInput ref={ref} {...props} />
+  return <TextInput ref={ref} {...props} />;
 }
 ```
 
 **Incorrect (useContext in React 19):**
 
 ```tsx
-const value = useContext(MyContext)
+const value = useContext(MyContext);
 ```
 
 **Correct (use instead of useContext):**
 
 ```tsx
-const value = use(MyContext)
+const value = use(MyContext);
 ```
 
 `use()` can also be called conditionally, unlike `useContext()`.

--- a/.agents/skills/vercel-composition-patterns/rules/state-context-interface.md
+++ b/.agents/skills/vercel-composition-patterns/rules/state-context-interface.md
@@ -20,8 +20,8 @@ dependency-injectable.
 ```tsx
 function ComposerInput() {
   // Tightly coupled to a specific hook
-  const { input, setInput } = useChannelComposerState()
-  return <TextInput value={input} onChangeText={setInput} />
+  const { input, setInput } = useChannelComposerState();
+  return <TextInput value={input} onChangeText={setInput} />;
 }
 ```
 
@@ -30,27 +30,27 @@ function ComposerInput() {
 ```tsx
 // Define a GENERIC interface that any provider can implement
 interface ComposerState {
-  input: string
-  attachments: Attachment[]
-  isSubmitting: boolean
+  input: string;
+  attachments: Attachment[];
+  isSubmitting: boolean;
 }
 
 interface ComposerActions {
-  update: (updater: (state: ComposerState) => ComposerState) => void
-  submit: () => void
+  update: (updater: (state: ComposerState) => ComposerState) => void;
+  submit: () => void;
 }
 
 interface ComposerMeta {
-  inputRef: React.RefObject<TextInput>
+  inputRef: React.RefObject<TextInput>;
 }
 
 interface ComposerContextValue {
-  state: ComposerState
-  actions: ComposerActions
-  meta: ComposerMeta
+  state: ComposerState;
+  actions: ComposerActions;
+  meta: ComposerMeta;
 }
 
-const ComposerContext = createContext<ComposerContextValue | null>(null)
+const ComposerContext = createContext<ComposerContextValue | null>(null);
 ```
 
 **UI components consume the interface, not the implementation:**
@@ -61,7 +61,7 @@ function ComposerInput() {
     state,
     actions: { update },
     meta,
-  } = use(ComposerContext)
+  } = use(ComposerContext);
 
   // This component works with ANY provider that implements the interface
   return (
@@ -70,7 +70,7 @@ function ComposerInput() {
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  )
+  );
 }
 ```
 
@@ -79,9 +79,9 @@ function ComposerInput() {
 ```tsx
 // Provider A: Local state for ephemeral forms
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState)
-  const inputRef = useRef(null)
-  const submit = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const inputRef = useRef(null);
+  const submit = useForwardMessage();
 
   return (
     <ComposerContext
@@ -93,13 +93,13 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </ComposerContext>
-  )
+  );
 }
 
 // Provider B: Global synced state for channels
 function ChannelProvider({ channelId, children }: Props) {
-  const { state, update, submit } = useGlobalChannel(channelId)
-  const inputRef = useRef(null)
+  const { state, update, submit } = useGlobalChannel(channelId);
+  const inputRef = useRef(null);
 
   return (
     <ComposerContext
@@ -111,7 +111,7 @@ function ChannelProvider({ channelId, children }: Props) {
     >
       {children}
     </ComposerContext>
-  )
+  );
 }
 ```
 
@@ -165,21 +165,21 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  )
+  );
 }
 
 // This button lives OUTSIDE Composer.Frame but can still submit based on its context!
 function ForwardButton() {
   const {
     actions: { submit },
-  } = use(ComposerContext)
-  return <Button onPress={submit}>Forward</Button>
+  } = use(ComposerContext);
+  return <Button onPress={submit}>Forward</Button>;
 }
 
 // This preview lives OUTSIDE Composer.Frame but can read composer's state!
 function MessagePreview() {
-  const { state } = use(ComposerContext)
-  return <Preview message={state.input} attachments={state.attachments} />
+  const { state } = use(ComposerContext);
+  return <Preview message={state.input} attachments={state.attachments} />;
 }
 ```
 

--- a/.agents/skills/vercel-composition-patterns/rules/state-decouple-implementation.md
+++ b/.agents/skills/vercel-composition-patterns/rules/state-decouple-implementation.md
@@ -16,18 +16,15 @@ useState, Zustand, or a server sync.
 ```tsx
 function ChannelComposer({ channelId }: { channelId: string }) {
   // UI component knows about global state implementation
-  const state = useGlobalChannelState(channelId)
-  const { submit, updateInput } = useChannelSync(channelId)
+  const state = useGlobalChannelState(channelId);
+  const { submit, updateInput } = useChannelSync(channelId);
 
   return (
     <Composer.Frame>
-      <Composer.Input
-        value={state.input}
-        onChange={(text) => sync.updateInput(text)}
-      />
+      <Composer.Input value={state.input} onChange={(text) => sync.updateInput(text)} />
       <Composer.Submit onPress={() => sync.submit()} />
     </Composer.Frame>
-  )
+  );
 }
 ```
 
@@ -39,21 +36,17 @@ function ChannelProvider({
   channelId,
   children,
 }: {
-  channelId: string
-  children: React.ReactNode
+  channelId: string;
+  children: React.ReactNode;
 }) {
-  const { state, update, submit } = useGlobalChannel(channelId)
-  const inputRef = useRef(null)
+  const { state, update, submit } = useGlobalChannel(channelId);
+  const inputRef = useRef(null);
 
   return (
-    <Composer.Provider
-      state={state}
-      actions={{ update, submit }}
-      meta={{ inputRef }}
-    >
+    <Composer.Provider state={state} actions={{ update, submit }} meta={{ inputRef }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 // UI component only knows about the context interface
@@ -66,7 +59,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  )
+  );
 }
 
 // Usage
@@ -75,7 +68,7 @@ function Channel({ channelId }: { channelId: string }) {
     <ChannelProvider channelId={channelId}>
       <ChannelComposer />
     </ChannelProvider>
-  )
+  );
 }
 ```
 
@@ -84,28 +77,25 @@ function Channel({ channelId }: { channelId: string }) {
 ```tsx
 // Local state for ephemeral forms
 function ForwardMessageProvider({ children }) {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
 
   return (
-    <Composer.Provider
-      state={state}
-      actions={{ update: setState, submit: forwardMessage }}
-    >
+    <Composer.Provider state={state} actions={{ update: setState, submit: forwardMessage }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 // Global synced state for channels
 function ChannelProvider({ channelId, children }) {
-  const { state, update, submit } = useGlobalChannel(channelId)
+  const { state, update, submit } = useGlobalChannel(channelId);
 
   return (
     <Composer.Provider state={state} actions={{ update, submit }}>
       {children}
     </Composer.Provider>
-  )
+  );
 }
 ```
 

--- a/.agents/skills/vercel-composition-patterns/rules/state-lift-state.md
+++ b/.agents/skills/vercel-composition-patterns/rules/state-lift-state.md
@@ -15,15 +15,15 @@ or awkward refs.
 
 ```tsx
 function ForwardMessageComposer() {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
 
   return (
     <Composer.Frame>
       <Composer.Input />
       <Composer.Footer />
     </Composer.Frame>
-  )
+  );
 }
 
 // Problem: How does this button access composer state?
@@ -37,7 +37,7 @@ function ForwardMessageDialog() {
         <ForwardButton /> {/* Needs to call submit */}
       </DialogActions>
     </Dialog>
-  )
+  );
 }
 ```
 
@@ -45,20 +45,20 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageDialog() {
-  const [input, setInput] = useState('')
+  const [input, setInput] = useState("");
   return (
     <Dialog>
       <ForwardMessageComposer onInputChange={setInput} />
       <MessagePreview input={input} />
     </Dialog>
-  )
+  );
 }
 
 function ForwardMessageComposer({ onInputChange }) {
-  const [state, setState] = useState(initialState)
+  const [state, setState] = useState(initialState);
   useEffect(() => {
-    onInputChange(state.input) // Sync on every change 😬
-  }, [state.input])
+    onInputChange(state.input); // Sync on every change 😬
+  }, [state.input]);
 }
 ```
 
@@ -66,13 +66,13 @@ function ForwardMessageComposer({ onInputChange }) {
 
 ```tsx
 function ForwardMessageDialog() {
-  const stateRef = useRef(null)
+  const stateRef = useRef(null);
   return (
     <Dialog>
       <ForwardMessageComposer stateRef={stateRef} />
       <ForwardButton onPress={() => submit(stateRef.current)} />
     </Dialog>
-  )
+  );
 }
 ```
 
@@ -80,9 +80,9 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState)
-  const forwardMessage = useForwardMessage()
-  const inputRef = useRef(null)
+  const [state, setState] = useState(initialState);
+  const forwardMessage = useForwardMessage();
+  const inputRef = useRef(null);
 
   return (
     <Composer.Provider
@@ -92,7 +92,7 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </Composer.Provider>
-  )
+  );
 }
 
 function ForwardMessageDialog() {
@@ -107,12 +107,12 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  )
+  );
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context)
-  return <Button onPress={actions.submit}>Forward</Button>
+  const { actions } = use(Composer.Context);
+  return <Button onPress={actions.submit}>Forward</Button>;
 }
 ```
 

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -31,6 +31,7 @@ Use WebFetch to retrieve the latest rules. The fetched content contains all the 
 ## Usage
 
 When a user provides a file or pattern argument:
+
 1. Fetch guidelines from the source URL above
 2. Read the specified files
 3. Apply all rules from the fetched guidelines

--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -40,6 +40,7 @@ paths:
 ## Architecture
 
 ### Layer responsibilities
+
 - **routes/** — HTTP concerns only: parse request, call service, format response. Never write DB queries directly.
 - **services/** — Business logic + data access. Receive `Kysely<Database>` via constructor. Own all query logic.
 - **schemas/** — Validation and response type definitions. Imported by routes. Must not import routes or services.
@@ -47,9 +48,11 @@ paths:
 - **middleware/** — Cross-cutting HTTP concerns. May import from lib. Must not import from services.
 
 ### Dependency rules
+
 ```
 routes → services → lib
 routes → schemas
 routes → middleware → lib
 ```
+
 Any import that violates these arrows is a design error. Extract shared code into the appropriate lower layer.

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -46,20 +46,24 @@ React 19 | TanStack Router + Query | Zustand | Tailwind v4 | Radix UI + CVA | Vi
 ## Architecture
 
 ### Layer responsibilities
+
 - **components/** — Rendering and user interaction. Get behavior via hooks, state via stores. Never call the API directly.
 - **hooks/** — Data fetching/mutation logic (TanStack Query wrappers) + pure functions for cache updates and data transforms.
 - **stores/** — Client-only state (auth, UI preferences). Keep thin. No API calls inside stores.
 - **lib/** — Pure utilities. Must not import React APIs.
 
 ### Dependency rules
+
 ```
 components → hooks → lib/api
 components → stores
 hooks → stores (read-only via getState())
 hooks → lib
 ```
+
 Components must not import `lib/api` directly — always go through a hook.
 
 ### Pure function extraction pattern
+
 Logic inside hooks that does not use React APIs (useState, useEffect, useQuery, etc.) should be named-exported from the same file.
 This enables unit testing without rendering (e.g. `updateReactionsInData`, `removeCommentById`).

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -123,7 +123,13 @@ describe("認証ルート", () => {
 
     const now = Math.floor(Date.now() / 1000);
     const token = await sign(
-      { sub: "non-existent-user", email: "test@example.com", type: "access", iat: now, exp: now + 900 },
+      {
+        sub: "non-existent-user",
+        email: "test@example.com",
+        type: "access",
+        iat: now,
+        exp: now + 900,
+      },
       mockEnv.JWT_ACCESS_SECRET,
       "HS256",
     );

--- a/apps/api/src/routes/comments.test.ts
+++ b/apps/api/src/routes/comments.test.ts
@@ -64,11 +64,7 @@ describe("コメントルート（単体操作）", () => {
     const app = new Hono();
     app.route("/comments", commentRoutes);
 
-    const res = await app.request(
-      "/comments/some-id",
-      { method: "DELETE" },
-      mockEnv,
-    );
+    const res = await app.request("/comments/some-id", { method: "DELETE" }, mockEnv);
 
     expect(res.status).toBe(401);
   });

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -685,7 +685,8 @@ const nodes = new Hono<HonoEnv>()
     describeRoute({
       tags: ["Nodes"],
       summary: "気になるユーザー一覧取得",
-      description: "ノードに気になる反応をしたユーザーの一覧を取得（カーソルベースのページネーション）",
+      description:
+        "ノードに気になる反応をしたユーザーの一覧を取得（カーソルベースのページネーション）",
       parameters: [
         {
           name: "limit",
@@ -748,7 +749,8 @@ const nodes = new Hono<HonoEnv>()
     describeRoute({
       tags: ["Nodes"],
       summary: "やってみたいユーザー一覧取得",
-      description: "ノードにやってみたい反応をしたユーザーの一覧を取得（カーソルベースのページネーション）",
+      description:
+        "ノードにやってみたい反応をしたユーザーの一覧を取得（カーソルベースのページネーション）",
       parameters: [
         {
           name: "limit",

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -120,12 +120,11 @@ export class NodeService {
     let baseQuery = this.db.selectFrom("nodes");
 
     if (params?.liked_by_user_id) {
-      baseQuery = baseQuery
-        .innerJoin("likes", (join) =>
-          join
-            .onRef("nodes.id", "=", "likes.node_id")
-            .on("likes.user_id", "=", params.liked_by_user_id!),
-        );
+      baseQuery = baseQuery.innerJoin("likes", (join) =>
+        join
+          .onRef("nodes.id", "=", "likes.node_id")
+          .on("likes.user_id", "=", params.liked_by_user_id!),
+      );
     }
 
     if (params?.parent_node_id) {

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://lh3.googleusercontent.com data: blob:; connect-src 'self' https://api.inspirehub.wtnqk.org https://cloudflareinsights.com; frame-src https://accounts.google.com; font-src 'self'

--- a/apps/web/src/components/BottomNav.tsx
+++ b/apps/web/src/components/BottomNav.tsx
@@ -10,7 +10,8 @@ const navItems = [
 export function BottomNav() {
   const matchRoute = useMatchRoute();
   const location = useLocation();
-  const isDetailPage = /^\/nodes\/[^/]+$/.test(location.pathname) && !location.pathname.endsWith("/new");
+  const isDetailPage =
+    /^\/nodes\/[^/]+$/.test(location.pathname) && !location.pathname.endsWith("/new");
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur-sm md:hidden">

--- a/apps/web/src/components/BottomNav.tsx
+++ b/apps/web/src/components/BottomNav.tsx
@@ -34,6 +34,7 @@ export function BottomNav() {
       {!isDetailPage && (
         <Link
           to="/nodes/new"
+          aria-label="新規ノード作成"
           className="absolute -top-16 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform"
         >
           <Plus size={24} />

--- a/apps/web/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/web/src/components/auth/GoogleLoginButton.tsx
@@ -28,7 +28,10 @@ export function GoogleLoginButton() {
         throw new Error(error.error?.message || "Authentication failed");
       }
 
-      const data = (await res.json()) as { user: Parameters<typeof setAuth>[0]; access_token: string };
+      const data = (await res.json()) as {
+        user: Parameters<typeof setAuth>[0];
+        access_token: string;
+      };
 
       setAuth(data.user, data.access_token);
     } catch (err) {

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -23,6 +23,7 @@ export function UserMenu() {
   return (
     <button
       onClick={handleLogout}
+      aria-label="ログアウト"
       className="rounded-lg p-2 text-muted-foreground hover:bg-secondary hover:text-foreground"
     >
       <LogOut size={18} />

--- a/apps/web/src/components/nodes/NodeCard.tsx
+++ b/apps/web/src/components/nodes/NodeCard.tsx
@@ -41,7 +41,9 @@ export function NodeCard({ node }: NodeCardProps) {
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
-          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${typeStyle.className}`}>
+          <span
+            className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${typeStyle.className}`}
+          >
             {typeStyle.icon && <typeStyle.icon size={12} />}
             {typeStyle.label}
           </span>

--- a/apps/web/src/components/nodes/ReactionButtons.tsx
+++ b/apps/web/src/components/nodes/ReactionButtons.tsx
@@ -23,18 +23,19 @@ export function ReactionButtons({ nodeId, reactions, variant = "compact" }: Reac
   if (variant === "compact") {
     return (
       <div className="flex items-center gap-1.5">
-        {reactionMeta.map(({ key, icon: Icon, color, bg }) => {
+        {reactionMeta.map(({ key, icon: Icon, label, color, bg }) => {
           const reaction = reactions[key];
           const isActive = reaction.is_reacted;
           return (
             <button
               key={key}
+              aria-label={label}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 mutation.mutate(key);
               }}
-              className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs active:scale-90 transition-transform ${
+              className={`flex items-center gap-1 rounded-full px-2.5 py-1.5 text-xs active:scale-90 transition-transform ${
                 isActive
                   ? `${bg} ${color}`
                   : "bg-secondary text-muted-foreground hover:bg-secondary/80"
@@ -93,6 +94,7 @@ function DetailReactionButtons({
           return (
             <div key={key} className="flex flex-col items-center">
               <button
+                aria-label={label}
                 {...(isMobile
                   ? {
                       onTouchStart: lp.onTouchStart,
@@ -116,6 +118,7 @@ function DetailReactionButtons({
                 <Icon size={20} className={isActive ? "fill-current" : ""} />
               </button>
               <button
+                aria-label={`${label}したユーザーを表示`}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/apps/web/src/components/nodes/ReactionButtons.tsx
+++ b/apps/web/src/components/nodes/ReactionButtons.tsx
@@ -13,8 +13,20 @@ interface ReactionButtonsProps {
 
 export const reactionMeta = [
   { key: "like", icon: Heart, label: "いいね", color: "text-rose-500", bg: "bg-rose-500/15" },
-  { key: "interested", icon: Flame, label: "気になる", color: "text-amber-500", bg: "bg-amber-500/15" },
-  { key: "want_to_try", icon: Rocket, label: "やってみたい", color: "text-violet-500", bg: "bg-violet-500/15" },
+  {
+    key: "interested",
+    icon: Flame,
+    label: "気になる",
+    color: "text-amber-500",
+    bg: "bg-amber-500/15",
+  },
+  {
+    key: "want_to_try",
+    icon: Rocket,
+    label: "やってみたい",
+    color: "text-violet-500",
+    bg: "bg-violet-500/15",
+  },
 ] as const;
 
 export function ReactionButtons({ nodeId, reactions, variant = "compact" }: ReactionButtonsProps) {
@@ -66,13 +78,10 @@ function DetailReactionButtons({
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerType, setDrawerType] = useState<ReactionType>("like");
 
-  const openDrawer = useCallback(
-    (type: ReactionType) => {
-      setDrawerType(type);
-      setDrawerOpen(true);
-    },
-    [],
-  );
+  const openDrawer = useCallback((type: ReactionType) => {
+    setDrawerType(type);
+    setDrawerOpen(true);
+  }, []);
 
   const likeLongPress = useLongPress({ onLongPress: () => openDrawer("like") });
   const interestedLongPress = useLongPress({ onLongPress: () => openDrawer("interested") });

--- a/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
+++ b/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
@@ -41,8 +41,11 @@ export function ReactionUsersDrawer({
     if (open) setActiveType(initialType);
   }, [open, initialType]);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useReactionUsers(nodeId, activeType, open);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useReactionUsers(
+    nodeId,
+    activeType,
+    open,
+  );
 
   const observerRef = useRef<IntersectionObserver | null>(null);
 
@@ -82,7 +85,9 @@ export function ReactionUsersDrawer({
             <span>{label}</span>
             <span className="text-xs tabular-nums">{reactions[key].count}</span>
             {isActive && (
-              <span className={`absolute inset-x-3 bottom-0 h-0.5 rounded-full ${color.replace("text-", "bg-")}`} />
+              <span
+                className={`absolute inset-x-3 bottom-0 h-0.5 rounded-full ${color.replace("text-", "bg-")}`}
+              />
             )}
           </button>
         );
@@ -116,18 +121,14 @@ export function ReactionUsersDrawer({
                     {(user.user_name ?? "?")[0]}
                   </div>
                 )}
-                <span className="text-sm font-medium">
-                  {user.user_name ?? "匿名ユーザー"}
-                </span>
+                <span className="text-sm font-medium">{user.user_name ?? "匿名ユーザー"}</span>
               </div>
               {i < users.length - 1 && <div className="border-b border-border/50" />}
             </div>
           ))}
           {hasNextPage && <div ref={sentinelRef} className="h-4" />}
           {isFetchingNextPage && (
-            <div className="py-3 text-center text-xs text-muted-foreground">
-              読み込み中...
-            </div>
+            <div className="py-3 text-center text-xs text-muted-foreground">読み込み中...</div>
           )}
         </div>
       )}
@@ -156,9 +157,7 @@ export function ReactionUsersDrawer({
       <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
         <DialogHeader className="px-6 pt-6 pb-4">
           <DialogTitle>リアクション</DialogTitle>
-          <DialogDescription className="sr-only">
-            リアクションしたユーザーの一覧
-          </DialogDescription>
+          <DialogDescription className="sr-only">リアクションしたユーザーの一覧</DialogDescription>
         </DialogHeader>
         {tabBar}
         <div className="min-h-[60vh] max-h-[70vh] overflow-y-auto">{userList}</div>

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -31,16 +31,8 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
   return <div className={cn("px-4 pb-2", className)} {...props} />;
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
-  return (
-    <DrawerPrimitive.Title
-      className={cn("text-lg font-semibold", className)}
-      {...props}
-    />
-  );
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return <DrawerPrimitive.Title className={cn("text-lg font-semibold", className)} {...props} />;
 }
 
 function DrawerDescription({
@@ -55,10 +47,4 @@ function DrawerDescription({
   );
 }
 
-export {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerDescription,
-};
+export { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription };

--- a/apps/web/src/hooks/use-comments.ts
+++ b/apps/web/src/hooks/use-comments.ts
@@ -68,17 +68,14 @@ export function usePostComment(nodeId: string) {
         replies: [],
       } as unknown as Comment;
 
-      queryClient.setQueryData<CommentsListResponse>(
-        ["nodes", nodeId, "comments"],
-        (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            comments: [...old.comments, tempComment],
-            total: old.total + 1,
-          };
-        },
-      );
+      queryClient.setQueryData<CommentsListResponse>(["nodes", nodeId, "comments"], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          comments: [...old.comments, tempComment],
+          total: old.total + 1,
+        };
+      });
 
       return { snapshot };
     },
@@ -116,16 +113,13 @@ export function useUpdateComment(nodeId: string) {
         "comments",
       ]);
 
-      queryClient.setQueryData<CommentsListResponse>(
-        ["nodes", nodeId, "comments"],
-        (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            comments: updateCommentContent(old.comments, commentId, content),
-          };
-        },
-      );
+      queryClient.setQueryData<CommentsListResponse>(["nodes", nodeId, "comments"], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          comments: updateCommentContent(old.comments, commentId, content),
+        };
+      });
 
       return { snapshot };
     },
@@ -161,18 +155,15 @@ export function useDeleteComment(nodeId: string) {
         "comments",
       ]);
 
-      queryClient.setQueryData<CommentsListResponse>(
-        ["nodes", nodeId, "comments"],
-        (old) => {
-          if (!old) return old;
-          const filtered = removeCommentById(old.comments, commentId);
-          return {
-            ...old,
-            comments: filtered,
-            total: old.total - (old.comments.length - filtered.length),
-          };
-        },
-      );
+      queryClient.setQueryData<CommentsListResponse>(["nodes", nodeId, "comments"], (old) => {
+        if (!old) return old;
+        const filtered = removeCommentById(old.comments, commentId);
+        return {
+          ...old,
+          comments: filtered,
+          total: old.total - (old.comments.length - filtered.length),
+        };
+      });
 
       return { snapshot };
     },

--- a/apps/web/src/hooks/use-debounce.test.ts
+++ b/apps/web/src/hooks/use-debounce.test.ts
@@ -22,10 +22,9 @@ describe("useDebounce", () => {
   });
 
   test("遅延時間内の再変更で前の値をキャンセルし最新値のみ反映する", async () => {
-    const { result, rerender } = renderHook(
-      ({ value, delay }) => useDebounce(value, delay),
-      { initialProps: { value: "first", delay: 300 } },
-    );
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: "first", delay: 300 },
+    });
 
     expect(result.current).toBe("first");
 

--- a/apps/web/src/hooks/use-long-press.ts
+++ b/apps/web/src/hooks/use-long-press.ts
@@ -27,16 +27,13 @@ export function useLongPress({ onLongPress, threshold = 500 }: UseLongPressOptio
   const onTouchMove = cancel;
   const onTouchEnd = cancel;
 
-  const onClick = useCallback(
-    (e: React.MouseEvent | React.TouchEvent) => {
-      if (firedRef.current) {
-        e.preventDefault();
-        e.stopPropagation();
-        firedRef.current = false;
-      }
-    },
-    [],
-  );
+  const onClick = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    if (firedRef.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      firedRef.current = false;
+    }
+  }, []);
 
   return { onTouchStart, onTouchMove, onTouchEnd, onClick };
 }

--- a/apps/web/src/hooks/use-reaction-users.ts
+++ b/apps/web/src/hooks/use-reaction-users.ts
@@ -8,27 +8,17 @@ type ReactionUsersResponse = InferResponseType<
   200
 >;
 
-function getReactionUsersFetcher(
-  nodeId: string,
-  type: ReactionType,
-  cursor?: string,
-) {
+function getReactionUsersFetcher(nodeId: string, type: ReactionType, cursor?: string) {
   const param = { id: nodeId };
   const query = cursor ? { cursor } : {};
 
-  if (type === "like")
-    return () => api.nodes[":id"].reactions.like.$get({ param, query });
+  if (type === "like") return () => api.nodes[":id"].reactions.like.$get({ param, query });
   if (type === "interested")
     return () => api.nodes[":id"].reactions.interested.$get({ param, query });
-  return () =>
-    api.nodes[":id"].reactions["want-to-try"].$get({ param, query });
+  return () => api.nodes[":id"].reactions["want-to-try"].$get({ param, query });
 }
 
-function useReactionUsersQuery(
-  nodeId: string,
-  type: ReactionType,
-  enabled: boolean,
-) {
+function useReactionUsersQuery(nodeId: string, type: ReactionType, enabled: boolean) {
   return useInfiniteQuery({
     queryKey: ["nodes", nodeId, "reaction-users", type],
     queryFn: async ({ pageParam }) => {

--- a/apps/web/src/hooks/use-toggle-reaction.ts
+++ b/apps/web/src/hooks/use-toggle-reaction.ts
@@ -2,10 +2,7 @@ import type { InferResponseType } from "hono/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, handleResponse } from "@/lib/api";
 
-type ReactionToggleResponse = InferResponseType<
-  (typeof api.nodes)[":id"]["like"]["$post"],
-  200
->;
+type ReactionToggleResponse = InferResponseType<(typeof api.nodes)[":id"]["like"]["$post"], 200>;
 
 interface ReactionStatus {
   count: number;

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,9 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  createRoute,
-  type AnyRootRoute,
-  useNavigate,
-} from "@tanstack/react-router";
+import { createRoute, type AnyRootRoute, useNavigate } from "@tanstack/react-router";
 import { motion, AnimatePresence } from "motion/react";
 import { GoogleLoginButton } from "@/components/auth/GoogleLoginButton";
 import { useAuthStore } from "@/stores/auth";

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -536,7 +536,6 @@ function NodeDetailContent({ id }: { id: string }) {
               parentContent={node.content}
             />
           </div>
-
         </>
       )}
 
@@ -561,13 +560,18 @@ function NodeDetailContent({ id }: { id: string }) {
                       className="group flex items-center gap-3 rounded-lg border border-border bg-secondary/20 p-3 transition-colors hover:border-primary/30 hover:bg-secondary/40"
                     >
                       {parentStyle.icon && (
-                        <parentStyle.icon size={20} className={`shrink-0 ${parentStyle.iconClassName}`} />
+                        <parentStyle.icon
+                          size={20}
+                          className={`shrink-0 ${parentStyle.iconClassName}`}
+                        />
                       )}
                       <div className="min-w-0 flex-1">
                         <span className={`text-xs font-medium ${parentStyle.iconClassName}`}>
                           派生元{parentStyle.label}
                         </span>
-                        <p className="mt-1 truncate text-sm font-medium">{node.parent_node.title}</p>
+                        <p className="mt-1 truncate text-sm font-medium">
+                          {node.parent_node.title}
+                        </p>
                       </div>
                     </Link>
                   </div>
@@ -592,7 +596,9 @@ function NodeDetailContent({ id }: { id: string }) {
                         派生先{style.label}
                       </span>
                       <p className="mt-1 truncate text-sm font-medium">{child.title}</p>
-                      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{child.content}</p>
+                      <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                        {child.content}
+                      </p>
                     </div>
                   </Link>
                 </div>
@@ -603,9 +609,7 @@ function NodeDetailContent({ id }: { id: string }) {
       )}
 
       <div className="mt-6">
-        <h2 className="font-semibold">
-          コメント {commentsQuery.data?.total ?? 0}
-        </h2>
+        <h2 className="font-semibold">コメント {commentsQuery.data?.total ?? 0}</h2>
 
         <form
           className="mt-3"

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -26,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -166,6 +167,9 @@ function DeriveIdeaDialog({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>派生アイデアを投稿</DialogTitle>
+            <DialogDescription className="sr-only">
+              選択したノードから派生するアイデアを作成します
+            </DialogDescription>
           </DialogHeader>
           <div className="mt-2">{formFields}</div>
           <Button

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -36,7 +36,7 @@ code {
   --card-foreground: oklch(0.15 0.01 260);
   --popover: oklch(0.97 0.003 260);
   --popover-foreground: oklch(0.15 0.01 260);
-  --primary: oklch(0.50 0.18 255);
+  --primary: oklch(0.5 0.18 255);
   --primary-foreground: oklch(0.99 0 0);
   --secondary: oklch(0.96 0.005 260);
   --secondary-foreground: oklch(0.25 0.01 260);
@@ -49,7 +49,7 @@ code {
   --border: oklch(0.93 0.005 260);
   --input: oklch(0.93 0.005 260);
   --ring: oklch(0.7 0.1 255);
-  --chart-1: oklch(0.50 0.18 255);
+  --chart-1: oklch(0.5 0.18 255);
   --chart-2: oklch(0.65 0.14 255);
   --chart-3: oklch(0.6 0.15 180);
   --chart-4: oklch(0.75 0.15 80);
@@ -57,12 +57,12 @@ code {
   --radius: 1rem;
   --sidebar: oklch(0.975 0.005 260);
   --sidebar-foreground: oklch(0.15 0.01 260);
-  --sidebar-primary: oklch(0.50 0.18 255);
+  --sidebar-primary: oklch(0.5 0.18 255);
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.96 0.005 260);
   --sidebar-accent-foreground: oklch(0.25 0.01 260);
   --sidebar-border: oklch(0.93 0.005 260);
-  --sidebar-ring: oklch(0.50 0.18 255);
+  --sidebar-ring: oklch(0.5 0.18 255);
 }
 
 .dark {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -36,7 +36,7 @@ code {
   --card-foreground: oklch(0.15 0.01 260);
   --popover: oklch(0.97 0.003 260);
   --popover-foreground: oklch(0.15 0.01 260);
-  --primary: oklch(0.55 0.18 255);
+  --primary: oklch(0.50 0.18 255);
   --primary-foreground: oklch(0.99 0 0);
   --secondary: oklch(0.96 0.005 260);
   --secondary-foreground: oklch(0.25 0.01 260);
@@ -49,7 +49,7 @@ code {
   --border: oklch(0.93 0.005 260);
   --input: oklch(0.93 0.005 260);
   --ring: oklch(0.7 0.1 255);
-  --chart-1: oklch(0.55 0.18 255);
+  --chart-1: oklch(0.50 0.18 255);
   --chart-2: oklch(0.65 0.14 255);
   --chart-3: oklch(0.6 0.15 180);
   --chart-4: oklch(0.75 0.15 80);
@@ -57,12 +57,12 @@ code {
   --radius: 1rem;
   --sidebar: oklch(0.975 0.005 260);
   --sidebar-foreground: oklch(0.15 0.01 260);
-  --sidebar-primary: oklch(0.55 0.18 255);
+  --sidebar-primary: oklch(0.50 0.18 255);
   --sidebar-primary-foreground: oklch(0.99 0 0);
   --sidebar-accent: oklch(0.96 0.005 260);
   --sidebar-accent-foreground: oklch(0.25 0.01 260);
   --sidebar-border: oklch(0.93 0.005 260);
-  --sidebar-ring: oklch(0.55 0.18 255);
+  --sidebar-ring: oklch(0.50 0.18 255);
 }
 
 .dark {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,9 @@ import { fileURLToPath, URL } from "node:url";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [devtools(), viteReact(), tailwindcss()],
+  build: {
+    sourcemap: "hidden",
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary

- **Accessibility**: aria-label追加、タッチターゲット拡大、コントラスト改善、DialogDescription追加
- **Best Practices**: `sourcemap: 'hidden'` でソースマップ生成を有効化
- **Security**: CSP ヘッダーを **Report-Only** で追加（違反の洗い出し用、ブロックなし）

## Changes

| Commit | Category |
|--------|----------|
| `fix(web): アクセシビリティ改善 — aria-label・タッチターゲット・コントラスト` | Accessibility |
| `fix(web): ソースマップ生成を有効化` | Best Practices |
| `feat(web): CSPヘッダーを追加` | Security (Report-Only) |
| `fix(web): DeriveIdeaDialogにDialogDescriptionを追加` | Accessibility |

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 53/53 passed
- [ ] デプロイ後、コンソールで CSP Report-Only の違反レポートを確認
- [ ] 違反内容を元に CSP ポリシーを調整後、本適用に切り替え

🤖 Generated with [Claude Code](https://claude.com/claude-code)