### PR TITLE
fix(web): 画像遅延ロード・a11y改善

### DIFF
--- a/apps/web/src/components/nodes/NodeCard.tsx
+++ b/apps/web/src/components/nodes/NodeCard.tsx
@@ -90,6 +90,9 @@ export function NodeCard({ node }: NodeCardProps) {
           <img
             src={node.author_picture}
             alt={node.author_name ?? ""}
+            loading="lazy"
+            width={20}
+            height={20}
             className="h-5 w-5 rounded-full"
           />
         )}

--- a/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
+++ b/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
@@ -113,7 +113,10 @@ export function ReactionUsersDrawer({
                 {user.user_picture ? (
                   <img
                     src={user.user_picture}
-                    alt=""
+                    alt={user.user_name ?? ""}
+                    loading="lazy"
+                    width={40}
+                    height={40}
                     className="h-10 w-10 rounded-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/components/nodes/TagInput.tsx
+++ b/apps/web/src/components/nodes/TagInput.tsx
@@ -51,6 +51,7 @@ export function TagInput({ tags, onTagsChange }: TagInputProps) {
               if (tagInput) setShowSuggestions(true);
             }}
             placeholder="タグ"
+            aria-label="タグを入力"
             className="h-7 w-28 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
             onKeyDown={(e) => {
               if (e.key === "Enter") {
@@ -62,6 +63,7 @@ export function TagInput({ tags, onTagsChange }: TagInputProps) {
           <button
             type="button"
             onClick={() => addTag(tagInput)}
+            aria-label="タグを追加"
             className="flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-secondary hover:text-foreground"
           >
             <Plus size={14} />
@@ -90,7 +92,11 @@ export function TagInput({ tags, onTagsChange }: TagInputProps) {
               className="flex items-center gap-1 rounded-md bg-secondary px-2 py-0.5 text-xs"
             >
               {tag}
-              <button type="button" onClick={() => onTagsChange(tags.filter((t) => t !== tag))}>
+              <button
+                type="button"
+                onClick={() => onTagsChange(tags.filter((t) => t !== tag))}
+                aria-label="タグを削除"
+              >
                 <X size={12} />
               </button>
             </span>

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -222,6 +222,9 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
         <img
           src={comment.author_picture}
           alt={comment.author_name ?? ""}
+          loading="lazy"
+          width={28}
+          height={28}
           className="mt-0.5 h-7 w-7 rounded-full"
         />
       )}
@@ -238,6 +241,7 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
                   setEditContent(comment.content);
                   setIsEditing(true);
                 }}
+                aria-label="コメントを編集"
                 className="rounded p-0.5 text-muted-foreground hover:text-foreground"
               >
                 <Pencil size={12} />
@@ -249,6 +253,7 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
                   }
                 }}
                 disabled={deleteComment.isPending}
+                aria-label="コメントを削除"
                 className="rounded p-0.5 text-muted-foreground hover:text-destructive"
               >
                 <Trash2 size={12} />
@@ -262,6 +267,7 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
               type="text"
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}
+              aria-label="コメントを編集"
               className="flex-1 rounded-lg border border-input bg-background px-3 py-1.5 text-sm"
               autoFocus
               onKeyDown={(e) => {
@@ -282,12 +288,14 @@ function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) 
                 )
               }
               disabled={updateComment.isPending || !editContent.trim()}
+              aria-label="編集を保存"
               className="rounded p-1 text-primary hover:bg-primary/10"
             >
               <Check size={14} />
             </button>
             <button
               onClick={() => setIsEditing(false)}
+              aria-label="編集をキャンセル"
               className="rounded p-1 text-muted-foreground hover:bg-secondary"
             >
               <X size={14} />
@@ -504,6 +512,9 @@ function NodeDetailContent({ id }: { id: string }) {
                 <img
                   src={node.author_picture}
                   alt={node.author_name ?? ""}
+                  loading="lazy"
+                  width={20}
+                  height={20}
                   className="h-5 w-5 rounded-full"
                 />
               )}
@@ -628,6 +639,7 @@ function NodeDetailContent({ id }: { id: string }) {
               value={commentText}
               onChange={(e) => setCommentText(e.target.value)}
               placeholder="コメントを入力"
+              aria-label="コメントを入力"
               className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm"
             />
             <Button type="submit" size="sm" disabled={postComment.isPending || !commentText.trim()}>

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -73,7 +73,14 @@ function ProfilePage() {
     <div className="p-4">
       <div className="flex items-center gap-4">
         {user.picture && (
-          <img src={user.picture} alt={user.name} className="h-16 w-16 rounded-full" />
+          <img
+            src={user.picture}
+            alt={user.name}
+            loading="lazy"
+            width={64}
+            height={64}
+            className="h-16 w-16 rounded-full"
+          />
         )}
         <div className="flex-1">
           {isEditingName ? (
@@ -93,6 +100,7 @@ function ProfilePage() {
               <button
                 onClick={() => updateName.mutate(editName.trim())}
                 disabled={updateName.isPending || !editName.trim()}
+                aria-label="保存"
                 className="rounded p-1 text-primary hover:bg-primary/10"
               >
                 {updateName.isPending ? (
@@ -103,6 +111,7 @@ function ProfilePage() {
               </button>
               <button
                 onClick={() => setIsEditingName(false)}
+                aria-label="キャンセル"
                 className="rounded p-1 text-muted-foreground hover:bg-secondary"
               >
                 <X size={16} />
@@ -116,6 +125,7 @@ function ProfilePage() {
                   setEditName(user.name);
                   setIsEditingName(true);
                 }}
+                aria-label="名前を編集"
                 className="rounded p-1 text-muted-foreground hover:text-foreground"
               >
                 <Pencil size={14} />


### PR DESCRIPTION
## Summary
- 全`<img>`に`loading="lazy"`と明示的な`width`/`height`を追加（CLS防止）
- アバター画像の`alt`テキストをユーザー名に修正（ReactionUsersDrawer）
- アイコンボタン9箇所に`aria-label`を追加（TagInput・profile・detail）
- フォーム入力3箇所に`aria-label`を追加（コメント入力・編集・タグ入力）

## Test plan
- [ ] Lighthouse Accessibilityスコアが改善されていることを確認
- [ ] 各画像に`loading="lazy"`属性が付与されていることをDevToolsで確認
- [ ] スクリーンリーダーでアイコンボタン・入力欄のラベルが読み上げられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)