### PR TITLE
fix(web): Lighthouse改善

### DIFF
--- a/apps/web/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/web/src/components/auth/GoogleLoginButton.tsx
@@ -1,9 +1,22 @@
+import { useState, useRef, useEffect } from "react";
 import { GoogleLogin, type CredentialResponse } from "@react-oauth/google";
 import { useAuthStore } from "@/stores/auth";
 import { env } from "@/env";
 
 export function GoogleLoginButton() {
   const { setAuth, setError, setLoading } = useAuthStore();
+  const [width, setWidth] = useState(400);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      setWidth(Math.floor(entry.contentRect.width));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const handleSuccess = async (response: CredentialResponse) => {
     if (!response.credential) {
@@ -46,13 +59,15 @@ export function GoogleLoginButton() {
   };
 
   return (
-    <GoogleLogin
-      onSuccess={handleSuccess}
-      onError={handleError}
-      useOneTap
-      theme="outline"
-      size="large"
-      width="100%"
-    />
+    <div ref={ref}>
+      <GoogleLogin
+        onSuccess={handleSuccess}
+        onError={handleError}
+        useOneTap
+        theme="outline"
+        size="large"
+        width={String(width)}
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -3,17 +3,16 @@ import { api } from "@/lib/api";
 import { LogOut } from "lucide-react";
 
 export function UserMenu() {
-  const { isAuthenticated, logout } = useAuthStore();
+  const { isAuthenticated, logout, accessToken } = useAuthStore();
 
   const handleLogout = async () => {
     if (!window.confirm("ログアウトしますか？")) return;
-    try {
-      await api.auth.logout.$post();
-    } catch (error) {
-      console.error("Logout error:", error);
-    } finally {
-      logout();
+    if (accessToken) {
+      try {
+        await api.auth.logout.$post();
+      } catch {}
     }
+    logout();
   };
 
   if (!isAuthenticated) {

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -174,6 +174,7 @@ function HomePage() {
 
   return (
     <div className="p-4">
+      <h1 className="sr-only">ホーム</h1>
       <div className="mb-4 hidden md:block">
         <InlineCompose />
       </div>
@@ -194,6 +195,7 @@ function HomePage() {
         ))}
       </div>
 
+      <h2 className="sr-only">投稿一覧</h2>
       <div className="mt-4 space-y-3">
         {isLoading && (
           <div className="flex justify-center py-12">

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -76,7 +76,7 @@ function ProfilePage() {
           <img
             src={user.picture}
             alt={user.name}
-            loading="lazy"
+            fetchPriority="high"
             width={64}
             height={64}
             className="h-16 w-16 rounded-full"

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -151,6 +151,7 @@ function ProfilePage() {
         ))}
       </div>
 
+      <h2 className="sr-only">投稿一覧</h2>
       <div className="mt-4 space-y-3">
         {data?.isLoading && (
           <div className="flex justify-center py-12">


### PR DESCRIPTION
## Summary

- GSIボタンの`width`をResizeObserverで測定したピクセル値に修正（`"100%"`は無効）
- ログアウト時、accessTokenが無ければAPI呼び出しをスキップして401エラーを抑制
- Home/Profileページにsr-only見出しを追加し、h1→h2→h3の正しい階層を確保
- プロフィールアバター（LCP候補）に`fetchPriority="high"`を追加

## Test plan

- [ ] GSIログインボタンがコンテナ幅に追従してリサイズされることを確認
- [ ] トークン期限切れ状態でログアウトしても401エラーが発生しないことを確認
- [ ] axe DevToolsで見出し階層スキップの警告が解消されていることを確認
- [ ] Lighthouse Performanceでプロフィール画像のLCP指摘が改善されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)