### PR TITLE
fix(web): Lighthouse改善

### DIFF
--- a/apps/web/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/web/src/components/auth/GoogleLoginButton.tsx
@@ -52,7 +52,7 @@ export function GoogleLoginButton() {
       useOneTap
       theme="outline"
       size="large"
-      width="100%"
+      width="400"
     />
   );
 }

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -3,17 +3,16 @@ import { api } from "@/lib/api";
 import { LogOut } from "lucide-react";
 
 export function UserMenu() {
-  const { isAuthenticated, logout } = useAuthStore();
+  const { isAuthenticated, logout, accessToken } = useAuthStore();
 
   const handleLogout = async () => {
     if (!window.confirm("ログアウトしますか？")) return;
-    try {
-      await api.auth.logout.$post();
-    } catch (error) {
-      console.error("Logout error:", error);
-    } finally {
-      logout();
+    if (accessToken) {
+      try {
+        await api.auth.logout.$post();
+      } catch {}
     }
+    logout();
   };
 
   if (!isAuthenticated) {

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -174,6 +174,7 @@ function HomePage() {
 
   return (
     <div className="p-4">
+      <h1 className="sr-only">ホーム</h1>
       <div className="mb-4 hidden md:block">
         <InlineCompose />
       </div>
@@ -194,6 +195,7 @@ function HomePage() {
         ))}
       </div>
 
+      <h2 className="sr-only">投稿一覧</h2>
       <div className="mt-4 space-y-3">
         {isLoading && (
           <div className="flex justify-center py-12">

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -76,7 +76,7 @@ function ProfilePage() {
           <img
             src={user.picture}
             alt={user.name}
-            loading="lazy"
+            fetchPriority="high"
             width={64}
             height={64}
             className="h-16 w-16 rounded-full"
@@ -151,6 +151,7 @@ function ProfilePage() {
         ))}
       </div>
 
+      <h2 className="sr-only">投稿一覧</h2>
       <div className="mt-4 space-y-3">
         {data?.isLoading && (
           <div className="flex justify-center py-12">


### PR DESCRIPTION
## Summary

- GSIボタンの`width`を固定ピクセル値`"400"`に変更（`"100%"`は無効なため）
- ログアウト時、accessTokenが無ければAPI呼び出しをスキップして401エラーを抑制
- Home/Profileページにsr-only見出しを追加し、h1→h2→h3の正しい階層を確保
- プロフィールアバター（LCP候補）の`loading="lazy"`を`fetchPriority="high"`に変更

## Test plan

- [ ] GSIログインボタンが正常に表示・動作することを確認
- [ ] トークン期限切れ状態でログアウトしても401エラーが発生しないことを確認
- [ ] axe DevToolsで見出し階層スキップの警告が解消されていることを確認
- [ ] Lighthouse Performanceでプロフィール画像のLCP指摘が改善されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)