### PR TITLE
fix(web): GSIボタンのwidthを100%に戻す

### DIFF
--- a/apps/web/src/components/auth/GoogleLoginButton.tsx
+++ b/apps/web/src/components/auth/GoogleLoginButton.tsx
@@ -52,7 +52,7 @@ export function GoogleLoginButton() {
       useOneTap
       theme="outline"
       size="large"
-      width="400"
+      width="100%"
     />
   );
 }


### PR DESCRIPTION
## Summary

- GSIボタンの`width`を固定値`"400"`から`"100%"`に戻す
- 400pxだとスマホでボタンがはみ出して見づらい
- GSI APIは無効な値を無視してデフォルト幅にフォールバックするだけで実害なし

## Test plan

- [ ] スマホ表示でGSIボタンがはみ出さないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)