### PR TITLE
fix(api): Slack通知のmrkdwnインジェクション防止

### DIFF
--- a/apps/api/src/notifications/slack.test.ts
+++ b/apps/api/src/notifications/slack.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { SlackNotificationService } from "./slack";
+
+let fetchCalls: { url: string | URL | Request; init?: RequestInit }[] = [];
+
+function createMockDb(rows: Record<string, unknown>[]) {
+  const chain = {
+    selectFrom: () => chain,
+    leftJoin: () => chain,
+    select: () => chain,
+    orderBy: () => chain,
+    where: () => chain,
+    execute: () => Promise.resolve(rows),
+  };
+  return chain as never;
+}
+
+function createMockKv(lastNotifiedAt: string | null = null) {
+  return {
+    get: mock(() => Promise.resolve(lastNotifiedAt)),
+    put: mock(() => Promise.resolve()),
+  } as unknown as KVNamespace;
+}
+
+function lastFetchPayload(): Record<string, unknown> {
+  const last = fetchCalls[fetchCalls.length - 1];
+  return JSON.parse(last.init?.body as string);
+}
+
+function mrkdwnTexts(payload: Record<string, unknown>): string[] {
+  const blocks = payload.blocks as { type: string; text?: { text: string }; fields?: { text: string }[] }[];
+  return blocks.flatMap((b) => {
+    if (b.fields) return b.fields.map((f) => f.text);
+    if (b.text?.text && b.type === "section") return [b.text.text];
+    return [];
+  });
+}
+
+const WEBHOOK_URL = "https://hooks.slack.com/test";
+const CLIENT_URL = "https://example.com";
+
+beforeEach(() => {
+  fetchCalls = [];
+  globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+    fetchCalls.push({ url, init });
+    return Promise.resolve(new Response("ok"));
+  }) as typeof fetch;
+});
+
+describe("SlackNotificationService", () => {
+  describe("mrkdwnエスケープ", () => {
+    it("リンク構文の < > がエスケープされる", async () => {
+      const db = createMockDb([
+        { id: "1", type: "idea", title: "<https://evil.com|Click>", content: "safe", author_name: "Alice", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[0]).toContain("&lt;https://evil.com|Click&gt;");
+      expect(texts[0]).not.toContain("<https://evil.com|Click>");
+    });
+
+    it("<!here> や <!channel> メンションがエスケープされる", async () => {
+      const db = createMockDb([
+        { id: "1", type: "issue", title: "<!here> <!channel>", content: "test", author_name: "Bob", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[0]).toContain("&lt;!here&gt;");
+      expect(texts[0]).not.toContain("<!here>");
+    });
+
+    it("author_name 内の mrkdwn がエスケープされる", async () => {
+      const db = createMockDb([
+        { id: "1", type: "idea", title: "ok", content: "ok", author_name: "<@U123>", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[1]).toContain("&lt;@U123&gt;");
+    });
+
+    it("content 内の mrkdwn がエスケープされる", async () => {
+      const db = createMockDb([
+        { id: "1", type: "project", title: "ok", content: "<https://phish.example|重要>", author_name: "Eve", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[2]).toContain("&lt;https://phish.example|重要&gt;");
+    });
+
+    it("& が二重エスケープを防ぐため最初に変換される", async () => {
+      const db = createMockDb([
+        { id: "1", type: "idea", title: "A&B <C>", content: "ok", author_name: "X", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[0]).toContain("A&amp;B &lt;C&gt;");
+    });
+
+    it("特殊文字を含まないテキストはそのまま出力される", async () => {
+      const db = createMockDb([
+        { id: "1", type: "idea", title: "普通のタイトル", content: "普通の内容", author_name: "太郎", created_at: "2025-01-01" },
+      ]);
+      const service = new SlackNotificationService(db, createMockKv(), WEBHOOK_URL, CLIENT_URL);
+
+      await service.notifyNewNodes();
+
+      const texts = mrkdwnTexts(lastFetchPayload());
+      expect(texts[0]).toBe("*タイトル*\n普通のタイトル");
+      expect(texts[1]).toBe("*投稿者*\n太郎");
+      expect(texts[2]).toBe("*詳細*\n普通の内容");
+    });
+  });
+});

--- a/apps/api/src/notifications/slack.ts
+++ b/apps/api/src/notifications/slack.ts
@@ -3,6 +3,10 @@ import type { Database } from "../lib/db";
 
 const KV_LAST_NOTIFIED_KEY = "slack:last_notified_at";
 
+function escapeSlackMrkdwn(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 interface NewNode {
   id: string;
   type: string;
@@ -91,11 +95,11 @@ export class SlackNotificationService {
           fields: [
             {
               type: "mrkdwn",
-              text: `*タイトル*\n${node.title}`,
+              text: `*タイトル*\n${escapeSlackMrkdwn(node.title)}`,
             },
             {
               type: "mrkdwn",
-              text: `*投稿者*\n${node.author_name || "Unknown"}`,
+              text: `*投稿者*\n${escapeSlackMrkdwn(node.author_name || "Unknown")}`,
             },
           ],
         },
@@ -103,7 +107,7 @@ export class SlackNotificationService {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `*詳細*\n${truncatedContent}`,
+            text: `*詳細*\n${escapeSlackMrkdwn(truncatedContent)}`,
           },
         },
         // TODO: Webページ実装後に有効化


### PR DESCRIPTION
## Summary
- Slack通知にユーザー入力（`title`, `content`, `author_name`）を埋め込む際、mrkdwn制御文字（`&`, `<`, `>`）をHTMLエンティティにエスケープするように修正
- これにより、`<url|text>` リンク注入、`<!here>` / `<!channel>` メンション注入、`<@U...>` ユーザーメンション注入を防止
- エスケープ処理を検証するテスト6ケースを追加

## Background
Slack のメッセージテキストでは `<`、`>`、`&` が特別な意味を持つ文字として扱われ、`<url|text>` や `<!here>`、`<@U...>` などの構文がリンクやメンションとして解釈されます。
このとき、ユーザー入力に含まれるこれらの文字は自動的には無害化されず、そのまま構文として解釈されます。

本プロダクトでは、認証済みユーザーがノードの title や content に任意のテキストを入力できるため、悪意のあるユーザーが mrkdwn 構文（例: `<https://phishing.example|重要なお知らせ>`, `<!channel>`, `<@UXXXX>`）を埋め込むことで、Slack チャンネルにフィッシングリンクや不要なメンション通知を送信できる状態でした。

この問題を防ぐため、Slack 通知にユーザー入力（title, content, author_name）を埋め込む際に、`<`、`>`、`&` を HTML エンティティ（`&lt;`, `&gt;`, `&amp;`）へエスケープする処理を追加し、ユーザー入力中の文字列が Slack によってリンクやメンションとして解釈されないようにしました。


## Test plan
- [x] `bun test` 全パス
- [x] `bun run lint` エラー・警告なし
- [ ] Slack通知で `<`, `>`, `&` を含むノードが正しくエスケープ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)