### PR TITLE
feat: liked_by→reacted_by フィルタ拡張・無限スクロール導入

### DIFF
--- a/apps/api/src/routes/nodes.test.ts
+++ b/apps/api/src/routes/nodes.test.ts
@@ -148,16 +148,16 @@ describe("ノードルート", () => {
     expect(res.status).toBe(400);
   });
 
-  test("GET /nodes?liked_by=me は未認証で401を返す", async () => {
+  test("GET /nodes?reacted_by=me は未認証で401を返す", async () => {
     const app = new Hono();
     app.route("/nodes", nodeRoutes);
 
-    const res = await app.request("/nodes?liked_by=me", { method: "GET" }, mockEnv);
+    const res = await app.request("/nodes?reacted_by=me", { method: "GET" }, mockEnv);
 
     expect(res.status).toBe(401);
   });
 
-  test("GET /nodes?liked_by=me は認証済みでノード一覧を返す", async () => {
+  test("GET /nodes?reacted_by=me は認証済みでノード一覧を返す", async () => {
     const app = new Hono();
     app.route("/nodes", nodeRoutes);
 
@@ -169,7 +169,7 @@ describe("ノードルート", () => {
     );
 
     const res = await app.request(
-      "/nodes?liked_by=me",
+      "/nodes?reacted_by=me",
       {
         method: "GET",
         headers: { Authorization: `Bearer ${token}` },

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -58,7 +58,7 @@ const nodes = new Hono<HonoEnv>()
           schema: { type: "string", enum: ["recent", "popular"] },
         },
         {
-          name: "liked_by",
+          name: "reacted_by",
           in: "query",
           required: false,
           schema: { type: "string", enum: ["me"] },
@@ -81,7 +81,7 @@ const nodes = new Hono<HonoEnv>()
           },
         },
         401: {
-          description: "認証エラー（liked_by=me使用時）",
+          description: "認証エラー（reacted_by=me使用時）",
           content: {
             "application/json": {
               schema: resolver(ErrorResponseSchema),
@@ -96,11 +96,11 @@ const nodes = new Hono<HonoEnv>()
       const query = c.req.valid("query") as ListNodesQuery;
       const userId = c.get("userId");
 
-      if (query.liked_by === "me" && !userId) {
+      if (query.reacted_by === "me" && !userId) {
         return c.json(
           {
             success: false as const,
-            error: { code: "UNAUTHORIZED", message: "Authentication required for liked_by=me" },
+            error: { code: "UNAUTHORIZED", message: "Authentication required for reacted_by=me" },
           },
           401,
         );
@@ -116,7 +116,7 @@ const nodes = new Hono<HonoEnv>()
         tag: query.tag,
         q: query.q,
         sort: query.sort,
-        liked_by_user_id: query.liked_by === "me" ? userId! : undefined,
+        reacted_by_user_id: query.reacted_by === "me" ? userId! : undefined,
         limit: query.limit || 20,
         offset: query.offset || 0,
       });

--- a/apps/api/src/schemas/node.ts
+++ b/apps/api/src/schemas/node.ts
@@ -23,7 +23,7 @@ export const ListNodesQuerySchema = type({
   "tag?": "string",
   "q?": "string",
   "sort?": "'recent' | 'popular'",
-  "liked_by?": "'me'",
+  "reacted_by?": "'me'",
   "limit?": type("string.numeric.parse").to("1 <= number <= 100"),
   "offset?": type("string.numeric.parse").to("number >= 0"),
 });

--- a/apps/api/src/services/node.ts
+++ b/apps/api/src/services/node.ts
@@ -91,17 +91,38 @@ export class NodeService {
     tag?: string;
     q?: string;
     sort?: "recent" | "popular";
-    liked_by_user_id?: string;
+    reacted_by_user_id?: string;
     limit?: number;
     offset?: number;
   }) {
     let baseQuery = this.db.selectFrom("nodes");
 
-    if (params?.liked_by_user_id) {
-      baseQuery = baseQuery.innerJoin("likes", (join) =>
-        join
-          .onRef("nodes.id", "=", "likes.node_id")
-          .on("likes.user_id", "=", params.liked_by_user_id!),
+    if (params?.reacted_by_user_id) {
+      const uid = params.reacted_by_user_id;
+      baseQuery = baseQuery.where((eb) =>
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom("likes")
+              .select(sql.lit(1).as("v"))
+              .whereRef("likes.node_id", "=", "nodes.id")
+              .where("likes.user_id", "=", uid),
+          ),
+          eb.exists(
+            eb
+              .selectFrom("interested")
+              .select(sql.lit(1).as("v"))
+              .whereRef("interested.node_id", "=", "nodes.id")
+              .where("interested.user_id", "=", uid),
+          ),
+          eb.exists(
+            eb
+              .selectFrom("want_to_try")
+              .select(sql.lit(1).as("v"))
+              .whereRef("want_to_try.node_id", "=", "nodes.id")
+              .where("want_to_try.user_id", "=", uid),
+          ),
+        ]),
       );
     }
 
@@ -162,8 +183,6 @@ export class NodeService {
         )`,
         "desc",
       );
-    } else if (params?.liked_by_user_id) {
-      query = query.orderBy(sql`likes.created_at`, "desc");
     } else {
       query = query.orderBy("nodes.created_at", "desc");
     }

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -10,7 +10,9 @@ export function UserMenu() {
     if (accessToken) {
       try {
         await api.auth.logout.$post();
-      } catch { /* logout API failure is non-critical */ }
+      } catch {
+        /* logout API failure is non-critical */
+      }
     }
     logout();
   };

--- a/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
+++ b/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
@@ -48,11 +48,7 @@ export function ReactionUsersDrawer({
     open,
   );
 
-  const sentinelRef = useInfiniteScroll(
-    hasNextPage ?? false,
-    isFetchingNextPage,
-    fetchNextPage,
-  );
+  const sentinelRef = useInfiniteScroll(hasNextPage ?? false, isFetchingNextPage, fetchNextPage);
 
   const users = data?.pages.flatMap((page) => page.data) ?? [];
 

--- a/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
+++ b/apps/web/src/components/nodes/ReactionUsersDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -14,6 +14,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { useReactionUsers } from "@/hooks/use-reaction-users";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { Reactions, ReactionType } from "@/hooks/use-toggle-reaction";
 
@@ -47,24 +48,10 @@ export function ReactionUsersDrawer({
     open,
   );
 
-  const observerRef = useRef<IntersectionObserver | null>(null);
-
-  useEffect(() => {
-    return () => observerRef.current?.disconnect();
-  }, []);
-
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      observerRef.current?.disconnect();
-      if (!node) return;
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          void fetchNextPage();
-        }
-      });
-      observerRef.current.observe(node);
-    },
-    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  const sentinelRef = useInfiniteScroll(
+    hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
   );
 
   const users = data?.pages.flatMap((page) => page.data) ?? [];

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -51,10 +51,4 @@ function DialogDescription({
   );
 }
 
-export {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-};
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription };

--- a/apps/web/src/hooks/use-infinite-scroll.ts
+++ b/apps/web/src/hooks/use-infinite-scroll.ts
@@ -1,0 +1,29 @@
+import { useRef, useEffect, useCallback } from "react";
+
+export function useInfiniteScroll(
+  hasNextPage: boolean,
+  isFetchingNextPage: boolean,
+  fetchNextPage: () => void,
+) {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect();
+      if (!node) return;
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+      observerRef.current.observe(node);
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
+
+  return sentinelRef;
+}

--- a/apps/web/src/hooks/use-nodes.ts
+++ b/apps/web/src/hooks/use-nodes.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { InferResponseType } from "hono/client";
+import { api, handleResponse } from "@/lib/api";
+
+type NodesListResponse = InferResponseType<(typeof api.nodes)["$get"], 200>;
+
+export function useInfiniteNodes(
+  params: { type?: string; author_id?: string; reacted_by?: "me" },
+  options?: { enabled?: boolean },
+) {
+  return useInfiniteQuery({
+    queryKey: ["nodes", params],
+    queryFn: async ({ pageParam = 0 }) => {
+      const query: Record<string, string> = { limit: "20", offset: String(pageParam) };
+      if (params.type) query.type = params.type;
+      if (params.author_id) query.author_id = params.author_id;
+      if (params.reacted_by) query.reacted_by = params.reacted_by;
+      const fetcher = () => api.nodes.$get({ query });
+      const res = await fetcher();
+      return handleResponse<NodesListResponse>(res, fetcher);
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((sum, p) => sum + p.nodes.length, 0);
+      return loaded < lastPage.total ? loaded : undefined;
+    },
+    enabled: options?.enabled,
+  });
+}

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { createRoute, type AnyRoute } from "@tanstack/react-router";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { InferResponseType } from "hono/client";
 import { Loader2 } from "lucide-react";
 import { api, handleResponse } from "@/lib/api";
 import { NODE_TYPE_STYLES, getToggleButtonColor } from "@/lib/node-types";
+import { useInfiniteNodes } from "@/hooks/use-nodes";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 
-type NodesListResponse = InferResponseType<(typeof api.nodes)["$get"], 200>;
 type NodeCreateResponse = InferResponseType<(typeof api.nodes)["$post"], 201>;
 import { useAuthStore } from "@/stores/auth";
 import { NodeCard } from "@/components/nodes/NodeCard";
@@ -15,11 +16,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 
-type NodeType = "issue" | "idea" | "project";
-
 interface Tab {
   label: string;
-  type?: NodeType;
+  type?: string;
   authorFilter?: boolean;
 }
 
@@ -29,28 +28,6 @@ const tabs: Tab[] = [
   { label: "アイデア", type: "idea" },
   { label: "自分", authorFilter: true },
 ];
-
-function useNodes(params: {
-  type?: NodeType;
-  author_id?: string;
-  limit?: number;
-  offset?: number;
-}) {
-  return useQuery({
-    queryKey: ["nodes", params],
-    queryFn: async () => {
-      const query: Record<string, string> = {};
-      if (params.type) query.type = params.type;
-      if (params.author_id) query.author_id = params.author_id;
-      if (params.limit) query.limit = String(params.limit);
-      if (params.offset) query.offset = String(params.offset);
-
-      const fetchNodes = () => api.nodes.$get({ query });
-      const res = await fetchNodes();
-      return handleResponse<NodesListResponse>(res, fetchNodes);
-    },
-  });
-}
 
 type ComposeType = "issue" | "idea";
 
@@ -159,11 +136,19 @@ function HomePage() {
   const { user } = useAuthStore();
   const tab = tabs[activeTab];
 
-  const { data, isLoading, error } = useNodes({
-    type: tab.type,
-    author_id: tab.authorFilter ? user?.id : undefined,
-    limit: 20,
-  });
+  const { data, isLoading, error, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteNodes({
+      type: tab.type,
+      author_id: tab.authorFilter ? user?.id : undefined,
+    });
+
+  const sentinelRef = useInfiniteScroll(
+    hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
+  );
+
+  const nodes = data?.pages.flatMap((p) => p.nodes) ?? [];
 
   return (
     <div className="p-4">
@@ -202,13 +187,20 @@ function HomePage() {
           </div>
         )}
 
-        {data?.nodes.length === 0 && !isLoading && (
+        {nodes.length === 0 && !isLoading && (
           <div className="py-12 text-center text-muted-foreground">ノードが見つかりません。</div>
         )}
 
-        {data?.nodes.map((node) => (
+        {nodes.map((node) => (
           <NodeCard key={node.id} node={node} />
         ))}
+
+        {hasNextPage && <div ref={sentinelRef} className="h-4" />}
+        {isFetchingNextPage && (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -142,11 +142,7 @@ function HomePage() {
       author_id: tab.authorFilter ? user?.id : undefined,
     });
 
-  const sentinelRef = useInfiniteScroll(
-    hasNextPage ?? false,
-    isFetchingNextPage,
-    fetchNextPage,
-  );
+  const sentinelRef = useInfiniteScroll(hasNextPage ?? false, isFetchingNextPage, fetchNextPage);
 
   const nodes = data?.pages.flatMap((p) => p.nodes) ?? [];
 

--- a/apps/web/src/routes/nodes/detail.tsx
+++ b/apps/web/src/routes/nodes/detail.tsx
@@ -185,7 +185,6 @@ function DeriveIdeaDialog({
   );
 }
 
-
 function CommentItem({ comment, nodeId }: { comment: Comment; nodeId: string }) {
   const { user } = useAuthStore();
   const [isEditing, setIsEditing] = useState(false);

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -152,7 +152,9 @@ function ProfilePage() {
 
         {nodes.length === 0 && !query.isLoading && (
           <div className="py-12 text-center text-muted-foreground">
-            {activeTab === "posts" ? "まだ投稿がありません。" : "リアクションした投稿はありません。"}
+            {activeTab === "posts"
+              ? "まだ投稿がありません。"
+              : "リアクションした投稿はありません。"}
           </div>
         )}
 

--- a/apps/web/src/routes/profile.tsx
+++ b/apps/web/src/routes/profile.tsx
@@ -1,19 +1,20 @@
 import { useState } from "react";
 import { createRoute, type AnyRoute } from "@tanstack/react-router";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import type { InferResponseType } from "hono/client";
 import { Loader2, Pencil, Check, X } from "lucide-react";
 import { api, handleResponse } from "@/lib/api";
 import { useAuthStore } from "@/stores/auth";
+import { useInfiniteNodes } from "@/hooks/use-nodes";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { NodeCard } from "@/components/nodes/NodeCard";
 import { Input } from "@/components/ui/input";
 
-type NodesListResponse = InferResponseType<(typeof api.nodes)["$get"], 200>;
 type UserUpdateResponse = InferResponseType<(typeof api.users)["me"]["$patch"], 200>;
 
 const profileTabs = [
   { label: "自分", key: "posts" },
-  { label: "いいね済み", key: "liked" },
+  { label: "リアクション済み", key: "reacted" },
 ] as const;
 
 type TabKey = (typeof profileTabs)[number]["key"];
@@ -24,32 +25,15 @@ function ProfilePage() {
   const [isEditingName, setIsEditingName] = useState(false);
   const [editName, setEditName] = useState("");
 
-  const myPosts = useQuery({
-    queryKey: ["nodes", { author_id: user?.id }],
-    queryFn: async () => {
-      if (!user) return { nodes: [] as NodesListResponse["nodes"], total: 0 };
-      const fetchMyPosts = () =>
-        api.nodes.$get({
-          query: { author_id: user.id, limit: 50 },
-        });
-      const res = await fetchMyPosts();
-      return handleResponse<NodesListResponse>(res, fetchMyPosts);
-    },
-    enabled: activeTab === "posts" && !!user,
-  });
+  const myPosts = useInfiniteNodes(
+    { author_id: user?.id },
+    { enabled: activeTab === "posts" && !!user },
+  );
 
-  const likedPosts = useQuery({
-    queryKey: ["nodes", { liked_by: "me" }],
-    queryFn: async () => {
-      const fetchLiked = () =>
-        api.nodes.$get({
-          query: { liked_by: "me" as const, limit: 50 },
-        });
-      const res = await fetchLiked();
-      return handleResponse<NodesListResponse>(res, fetchLiked);
-    },
-    enabled: activeTab === "liked" && !!user,
-  });
+  const reactedPosts = useInfiniteNodes(
+    { reacted_by: "me" },
+    { enabled: activeTab === "reacted" && !!user },
+  );
 
   const updateName = useMutation({
     mutationFn: async (name: string) => {
@@ -65,9 +49,16 @@ function ProfilePage() {
     },
   });
 
-  if (!user) return null;
+  const query = activeTab === "posts" ? myPosts : reactedPosts;
+  const nodes = query.data?.pages.flatMap((p) => p.nodes) ?? [];
 
-  const data = activeTab === "posts" ? myPosts : likedPosts;
+  const sentinelRef = useInfiniteScroll(
+    query.hasNextPage ?? false,
+    query.isFetchingNextPage,
+    query.fetchNextPage,
+  );
+
+  if (!user) return null;
 
   return (
     <div className="p-4">
@@ -153,21 +144,28 @@ function ProfilePage() {
 
       <h2 className="sr-only">投稿一覧</h2>
       <div className="mt-4 space-y-3">
-        {data?.isLoading && (
+        {query.isLoading && (
           <div className="flex justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
         )}
 
-        {data?.data?.nodes.length === 0 && !data?.isLoading && (
+        {nodes.length === 0 && !query.isLoading && (
           <div className="py-12 text-center text-muted-foreground">
-            {activeTab === "posts" ? "まだ投稿がありません。" : "いいねした投稿はありません。"}
+            {activeTab === "posts" ? "まだ投稿がありません。" : "リアクションした投稿はありません。"}
           </div>
         )}
 
-        {data?.data?.nodes.map((node) => (
+        {nodes.map((node) => (
           <NodeCard key={node.id} node={node} />
         ))}
+
+        {query.hasNextPage && <div ref={sentinelRef} className="h-4" />}
+        {query.isFetchingNextPage && (
+          <div className="flex justify-center py-4">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- API `liked_by` クエリパラメータを `reacted_by` に改名し、likes / interested / want_to_try 3テーブルを `WHERE EXISTS ... OR` で結合するフィルタに変更
- `useInfiniteNodes` / `useInfiniteScroll` フックを新規作成し、ホーム・プロフィール画面にオフセットベースの無限スクロールを実装
- プロフィール画面「いいね済み」タブを「リアクション済み」に変更し、全リアクション種別でフィルタ
- `ReactionUsersDrawer` のインライン IntersectionObserver を共通フックに抽出

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `apps/api/src/schemas/node.ts` | `liked_by` → `reacted_by` |
| `apps/api/src/routes/nodes.ts` | パラメータ名・ハンドラ更新 |
| `apps/api/src/services/node.ts` | WHERE EXISTS 3テーブル OR フィルタ |
| `apps/api/src/routes/nodes.test.ts` | テスト更新 |
| `apps/web/src/hooks/use-nodes.ts` | **新規** — `useInfiniteNodes` |
| `apps/web/src/hooks/use-infinite-scroll.ts` | **新規** — `useInfiniteScroll` |
| `apps/web/src/routes/home.tsx` | 無限スクロール化 |
| `apps/web/src/routes/profile.tsx` | リアクション済み + 無限スクロール化 |
| `apps/web/src/components/nodes/ReactionUsersDrawer.tsx` | hook 抽出による簡素化 |

## Test plan

- [ ] `bun run lint` — 0 errors
- [ ] `bun test apps/api/` — 50/50 pass
- [ ] ホーム「すべて」タブで20件超スクロール → 追加読み込み
- [ ] ホーム「課題」「アイデア」「自分」タブで同様に動作
- [ ] プロフィール「リアクション済み」タブで like / interested / want_to_try いずれかにリアクションしたノードが表示
- [ ] プロフィール「自分」タブで無限スクロール動作
- [ ] タブ切り替え時にデータが正しくリセット

🤖 Generated with [Claude Code](https://claude.com/claude-code)