### PR TITLE
fix(api): KV namespace 設定をコメントアウトしてデプロイ復旧

### DIFF
--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -20,16 +20,17 @@
     },
   ],
 
-  "kv_namespaces": [
-    {
-      "binding": "KV",
-      "id": "inspirehub-kv"
-    }
-  ],
+  // TODO: KV namespace ID を正しい UUID に差し替えてから有効化
+  // "kv_namespaces": [
+  //   {
+  //     "binding": "KV",
+  //     "id": "<UUID from `wrangler kv namespace list`>"
+  //   }
+  // ],
 
-  "triggers": {
-    "crons": ["* * * * *"]
-  },
+  // "triggers": {
+  //   "crons": ["* * * * *"]
+  // },
 
   "vars": {
     "ENVIRONMENT": "develop",


### PR DESCRIPTION
## Summary

- PR #76 で追加された `kv_namespaces.id` が UUID ではなく名前文字列 `"inspirehub-kv"` だったため、`wrangler deploy` が `code: 10042` で 2/15 以降全て失敗していた
- 通知機能（cron + KV）は未使用のため、正しい ID が判明するまでコメントアウト

## Test plan

- [ ] マージ後の Deploy API ワークフローが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)