### PR TITLE
fix(web): 楽観的更新の InfiniteQuery 対応

### DIFF
--- a/apps/web/src/hooks/use-infinite-scroll.ts
+++ b/apps/web/src/hooks/use-infinite-scroll.ts
@@ -15,11 +15,14 @@ export function useInfiniteScroll(
     (node: HTMLDivElement | null) => {
       observerRef.current?.disconnect();
       if (!node) return;
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      });
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+          }
+        },
+        { rootMargin: "200px" },
+      );
       observerRef.current.observe(node);
     },
     [hasNextPage, isFetchingNextPage, fetchNextPage],

--- a/apps/web/src/hooks/use-nodes.ts
+++ b/apps/web/src/hooks/use-nodes.ts
@@ -4,6 +4,8 @@ import { api, handleResponse } from "@/lib/api";
 
 type NodesListResponse = InferResponseType<(typeof api.nodes)["$get"], 200>;
 
+const PAGE_SIZE = 20;
+
 export function useInfiniteNodes(
   params: { type?: string; author_id?: string; reacted_by?: "me" },
   options?: { enabled?: boolean },
@@ -11,7 +13,7 @@ export function useInfiniteNodes(
   return useInfiniteQuery({
     queryKey: ["nodes", params],
     queryFn: async ({ pageParam = 0 }) => {
-      const query: Record<string, string> = { limit: "20", offset: String(pageParam) };
+      const query: Record<string, string> = { limit: String(PAGE_SIZE), offset: String(pageParam) };
       if (params.type) query.type = params.type;
       if (params.author_id) query.author_id = params.author_id;
       if (params.reacted_by) query.reacted_by = params.reacted_by;

--- a/apps/web/src/hooks/use-toggle-reaction.test.ts
+++ b/apps/web/src/hooks/use-toggle-reaction.test.ts
@@ -97,4 +97,30 @@ describe("updateReactionsInData", () => {
     expect(data.reactions.want_to_try.is_reacted).toBe(true);
     expect(data.reactions.want_to_try.count).toBe(3);
   });
+
+  test("InfiniteQuery形状のデータで該当ノードのリアクションを切り替える", () => {
+    const data = {
+      pages: [
+        { nodes: [{ id: "node-1", reactions: makeReactions(2) }], total: 3 },
+        { nodes: [{ id: "node-2", reactions: makeReactions(1) }], total: 3 },
+      ],
+      pageParams: [0, 20],
+    };
+    const result = updateReactionsInData(data, "node-2", "like");
+
+    expect(result).toBe(true);
+    expect(data.pages[1].nodes[0].reactions.like.is_reacted).toBe(true);
+    expect(data.pages[1].nodes[0].reactions.like.count).toBe(2);
+    expect(data.pages[0].nodes[0].reactions.like.count).toBe(2);
+  });
+
+  test("InfiniteQuery形状で該当ノードがない場合falseを返す", () => {
+    const data = {
+      pages: [{ nodes: [{ id: "node-1", reactions: makeReactions() }], total: 1 }],
+      pageParams: [0],
+    };
+    const result = updateReactionsInData(data, "node-999", "like");
+
+    expect(result).toBe(false);
+  });
 });

--- a/apps/web/src/hooks/use-toggle-reaction.ts
+++ b/apps/web/src/hooks/use-toggle-reaction.ts
@@ -56,6 +56,13 @@ export function updateReactionsInData(data: unknown, nodeId: string, type: React
     }
   }
 
+  // InfiniteQuery shape: { pages: [{ nodes, total }, ...], pageParams }
+  if ("pages" in detail && Array.isArray(detail.pages)) {
+    for (const page of detail.pages as unknown[]) {
+      if (updateReactionsInData(page, nodeId, type)) return true;
+    }
+  }
+
   return false;
 }
 

--- a/apps/web/src/routes/home.tsx
+++ b/apps/web/src/routes/home.tsx
@@ -7,14 +7,14 @@ import { api, handleResponse } from "@/lib/api";
 import { NODE_TYPE_STYLES, getToggleButtonColor } from "@/lib/node-types";
 import { useInfiniteNodes } from "@/hooks/use-nodes";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
-
-type NodeCreateResponse = InferResponseType<(typeof api.nodes)["$post"], 201>;
 import { useAuthStore } from "@/stores/auth";
 import { NodeCard } from "@/components/nodes/NodeCard";
 import { TagInput } from "@/components/nodes/TagInput";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+
+type NodeCreateResponse = InferResponseType<(typeof api.nodes)["$post"], 201>;
 
 interface Tab {
   label: string;


### PR DESCRIPTION
## Summary

- `useQuery` → `useInfiniteQuery` 移行により、キャッシュ形状が `{ nodes, total }` から `{ pages: [{ nodes, total }, ...], pageParams }` に変わったが、`updateReactionsInData` が `pages` 配列を走査していなかった
- 一覧画面でリアクション切り替え時に即時反映されない問題を修正
- `pages` プロパティがある場合、各ページに対して再帰的に処理する分岐を追加
- `useInfiniteScroll` に `rootMargin: "200px"` を追加し、ビューポート到達前に prefetch 開始
- `useInfiniteNodes` の limit をマジックナンバーから `PAGE_SIZE` 定数に抽出
- `home.tsx` の import 順序を修正

## Test plan

- [ ] `bun run lint` — 0 errors
- [ ] ホーム画面でリアクション切り替え → 即時に count / is_reacted が反映
- [ ] プロフィール画面でも同様
- [ ] 2ページ目以降のノードでも楽観的更新が効くこと
- [ ] スクロール時に次ページがスムーズに読み込まれること（途切れなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)